### PR TITLE
feat: implement platform-specific templates, multi-platform post , char validation, and CSV export presets

### DIFF
--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -86,6 +86,256 @@ DEFAULT_TEMPLATES = {
 }
 
 # ---------------------------------------------------------------------------
+# Supported social media platforms
+# ---------------------------------------------------------------------------
+
+PLATFORMS = {
+    "twitter": "X / Twitter",
+    "mastodon": "Mastodon",
+    "telegram": "Telegram",
+    "linkedin": "LinkedIn",
+}
+
+# Platform-specific default template overrides.
+# Keys mirror DEFAULT_TEMPLATES; any missing key falls back to DEFAULT_TEMPLATES.
+# Twitter templates are trimmed for the 280-char limit.
+# Telegram/LinkedIn templates allow richer formatting.
+
+PLATFORM_DEFAULT_TEMPLATES = {
+    "twitter": {
+        "cfp": {
+            "announcement": (
+                "📢 Submit your proposals for {event_name}! "
+                "Deadline: {cfp_deadline}. {cfp_link} {hashtags}"
+            ),
+            "reminder": (
+                "⏰ CFP Closing Soon for {event_name}! "
+                "Deadline {cfp_deadline}. {cfp_link} {hashtags}"
+            ),
+            "final_call": (
+                "🚨 Last call! Submit to {event_name} by {cfp_deadline}: {cfp_link} {hashtags}"
+            ),
+        },
+        "speaker": {
+            "announcement": (
+                "🎤 Meet our speaker {speaker_name} at {event_name}! "
+                "'{talk_title}' {speaker_link} {hashtags}"
+            ),
+            "reminder": (
+                "🗓 Don't miss {speaker_name} on '{talk_title}' at {event_name}! "
+                "{speaker_link} {hashtags}"
+            ),
+            "final_call": (
+                "🔥 {speaker_name} presenting '{talk_title}' at {event_name}. "
+                "Live soon! {speaker_link} {hashtags}"
+            ),
+        },
+        "session": {
+            "announcement": (
+                "🗓 Coming up: '{talk_title}' by {speaker_names} at {event_name}. "
+                "{talk_link} {hashtags}"
+            ),
+            "reminder": (
+                "⏰ Starting soon: '{talk_title}' at {talk_start_time}. "
+                "{talk_link} {hashtags}"
+            ),
+            "final_call": (
+                "🔥 Starting now: '{talk_title}' in {talk_room}. {talk_link} {hashtags}"
+            ),
+        },
+        "ticket": {
+            "announcement": (
+                "🎟 {ticket_name} tickets for {event_name} — {ticket_price}. "
+                "Get yours: {ticket_link} {hashtags}"
+            ),
+            "reminder": (
+                "⚡ Don't miss {ticket_name} for {event_name}! {ticket_link} {hashtags}"
+            ),
+            "final_call": (
+                "🔥 Last chance! {ticket_name} for {event_name}. {ticket_link} {hashtags}"
+            ),
+        },
+        "schedule": {
+            "announcement": (
+                "📅 Full schedule for {event_name} is live! {schedule_link} {hashtags}"
+            ),
+            "reminder": (
+                "🗓 Check the {event_name} schedule: {schedule_link} {hashtags}"
+            ),
+        },
+    },
+    "mastodon": {
+        # Mastodon allows 500 chars; templates can be slightly richer than Twitter
+        "cfp": {
+            "announcement": (
+                "📢 Submit your proposals for {event_name}!\n"
+                "Deadline: {cfp_deadline}.\nApply here: {cfp_link} {hashtags}"
+            ),
+            "reminder": (
+                "⏰ CFP Closing Soon for {event_name}!\n"
+                "Only a few days left ({cfp_deadline}): {cfp_link} {hashtags}"
+            ),
+            "final_call": (
+                "🚨 Final Call! Submissions for {event_name} close {cfp_deadline}.\n"
+                "Submit now: {cfp_link} {hashtags}"
+            ),
+        },
+        "speaker": DEFAULT_TEMPLATES["speaker"],
+        "session": DEFAULT_TEMPLATES["session"],
+        "ticket": DEFAULT_TEMPLATES["ticket"],
+        "schedule": DEFAULT_TEMPLATES["schedule"],
+    },
+    "telegram": {
+        # Telegram supports Markdown; use bold via *text*
+        "cfp": {
+            "announcement": (
+                "📢 *CFP Open* for *{event_name}*!\n"
+                "Deadline: *{cfp_deadline}*\nSubmit: {cfp_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "⏰ *CFP Reminder* — {event_name}\n"
+                "Deadline: *{cfp_deadline}*\n{cfp_link}\n{hashtags}"
+            ),
+            "final_call": (
+                "🚨 *Final Call* — {event_name}\n"
+                "Submit by *{cfp_deadline}*: {cfp_link}\n{hashtags}"
+            ),
+        },
+        "speaker": {
+            "announcement": (
+                "🎤 *Speaker Spotlight* — {event_name}\n"
+                "*{speaker_name}* will present *'{talk_title}'*\n"
+                "More info: {speaker_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "🗓 *Don't miss* {speaker_name} presenting *'{talk_title}'* at {event_name}!\n"
+                "{speaker_link}\n{hashtags}"
+            ),
+            "final_call": (
+                "🔥 *Live soon!* {speaker_name} — *'{talk_title}'* at {event_name}\n"
+                "{speaker_link}\n{hashtags}"
+            ),
+        },
+        "session": {
+            "announcement": (
+                "🗓 *Upcoming Session* — {event_name}\n"
+                "*'{talk_title}'* by {speaker_names}\n"
+                "Room: {talk_room} | Time: {talk_start_time}\n"
+                "{talk_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "⏰ *Session Starting Soon* — {event_name}\n"
+                "*'{talk_title}'* by {speaker_names} at {talk_start_time}\n"
+                "{talk_link}\n{hashtags}"
+            ),
+            "final_call": (
+                "🔥 *Starting Now!* *'{talk_title}'* by {speaker_names} in {talk_room}\n"
+                "Join: {talk_link}\n{hashtags}"
+            ),
+        },
+        "ticket": {
+            "announcement": (
+                "🎟 *Tickets Available* — {event_name}\n"
+                "*{ticket_name}* — {ticket_price}\nGet yours: {ticket_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "⚡ *Ticket Reminder* — {event_name}\n"
+                "{ticket_name}: {ticket_link}\n{hashtags}"
+            ),
+            "final_call": (
+                "🔥 *Last Chance!* {ticket_name} for {event_name}\n"
+                "{ticket_link}\n{hashtags}"
+            ),
+        },
+        "schedule": {
+            "announcement": (
+                "📅 *Schedule Live* — {event_name}\n"
+                "Plan your days: {schedule_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "🗓 *Check the Schedule* — {event_name}\n"
+                "{schedule_link}\n{hashtags}"
+            ),
+        },
+    },
+    "linkedin": {
+        # LinkedIn allows long-form; use professional tone
+        "cfp": {
+            "announcement": (
+                "We're excited to open our Call for Proposals for {event_name}! "
+                "Share your expertise with our community. The submission deadline is {cfp_deadline}. "
+                "Submit your proposal here: {cfp_link} {hashtags}"
+            ),
+            "reminder": (
+                "⏰ Reminder: The CFP for {event_name} closes on {cfp_deadline}. "
+                "Don't miss this opportunity to present your ideas. Submit now: {cfp_link} {hashtags}"
+            ),
+            "final_call": (
+                "Final call! Submissions for {event_name} close on {cfp_deadline}. "
+                "This is your last chance to be part of our speaker lineup. "
+                "Submit here: {cfp_link} {hashtags}"
+            ),
+        },
+        "speaker": {
+            "announcement": (
+                "We're thrilled to feature {speaker_name} at {event_name}! "
+                "Join us for their talk: '{talk_title}'. "
+                "Learn more about this session: {speaker_link} {hashtags}"
+            ),
+            "reminder": (
+                "Don't miss {speaker_name} presenting '{talk_title}' at {event_name}. "
+                "A session not to be missed! Details: {speaker_link} {hashtags}"
+            ),
+            "final_call": (
+                "Spotlight: {speaker_name} will be presenting '{talk_title}' at {event_name}. "
+                "Join us live! {speaker_link} {hashtags}"
+            ),
+        },
+        "session": {
+            "announcement": (
+                "Mark your calendars! '{talk_title}' by {speaker_names} is coming up at {event_name}. "
+                "Room: {talk_room} | Time: {talk_start_time}. Full details: {talk_link} {hashtags}"
+            ),
+            "reminder": (
+                "Session starting soon: '{talk_title}' by {speaker_names} "
+                "at {talk_start_time} in {talk_room} during {event_name}. "
+                "Don't miss it: {talk_link} {hashtags}"
+            ),
+            "final_call": (
+                "Starting now: '{talk_title}' by {speaker_names} in {talk_room}. "
+                "Join the session: {talk_link} {hashtags}"
+            ),
+        },
+        "ticket": {
+            "announcement": (
+                "Tickets for {event_name} are now available! "
+                "Secure your {ticket_name} ticket for just {ticket_price}. "
+                "Register now: {ticket_link} {hashtags}"
+            ),
+            "reminder": (
+                "Have you registered for {event_name} yet? "
+                "{ticket_name} tickets ({ticket_price}) are still available: {ticket_link} {hashtags}"
+            ),
+            "final_call": (
+                "Last chance to register for {event_name}! "
+                "Grab your {ticket_name} ticket now: {ticket_link} {hashtags}"
+            ),
+        },
+        "schedule": {
+            "announcement": (
+                "The full schedule for {event_name} is now live! "
+                "Explore all sessions, workshops, and keynotes. "
+                "Plan your experience: {schedule_link} {hashtags}"
+            ),
+            "reminder": (
+                "Have you checked out the {event_name} schedule? "
+                "Browse all sessions and plan your agenda: {schedule_link} {hashtags}"
+            ),
+        },
+    },
+}
+
+# ---------------------------------------------------------------------------
 # Distance-based template context mapping
 # ---------------------------------------------------------------------------
 # Maps offset thresholds to template context keys.  For each post type,
@@ -192,6 +442,29 @@ def _get_template(event, key, context="announcement"):
     return tpl
 
 
+def _get_platform_template(event, key, platform, context="announcement"):
+    """Return a platform-specific template, cascading through:
+    1. Organizer-saved per-platform custom override
+    2. Baked-in platform-specific default
+    3. Existing generic default template
+    """
+    # 1. Check for organizer-saved platform-specific override
+    custom = event.settings.get(f"socialmedia_{platform}_{key}_template")
+    if custom:
+        return custom
+
+    # 2. Baked-in platform-specific default
+    plat_tpls = PLATFORM_DEFAULT_TEMPLATES.get(platform, {})
+    plat_tpl = plat_tpls.get(key, {})
+    if isinstance(plat_tpl, dict):
+        result = plat_tpl.get(context) or plat_tpl.get("announcement")
+        if result:
+            return result
+
+    # 3. Fall back to generic default
+    return _get_template(event, key, context)
+
+
 def _get_template_for_offset(event, key, offset_value):
     """Return the template matching the distance-based wave for this offset."""
     context = resolve_template_context(key, offset_value)
@@ -237,11 +510,24 @@ def build_posts(event, request=None):
     """
     Return a list of post dicts built from the event's live DB data.
     Each dict has: type, type_label, post_date, post_time, post_text.
+    When at least one platform is enabled, each content item generates one
+    draft per enabled platform (with a 'platform' and 'platform_label' key).
+    If no platforms are enabled the function falls back to the original
+    platform-agnostic behaviour (one generic draft per content item).
     The list is sorted chronologically.
     """
     hashtags = event.settings.get("socialmedia_default_hashtags", "")
     event_link_override = event.settings.get("socialmedia_event_link")
     event_link = event_link_override or event_absolute_url(event.urls.base, request)
+
+    # Determine which platforms are enabled
+    enabled_platforms = [
+        p
+        for p in PLATFORMS
+        if event.settings.get(f"socialmedia_{p}_enabled", False, as_type=bool)
+    ]
+    # Fall back to generic (no platform tagging) when none are configured
+    use_platforms = bool(enabled_platforms)
 
     posts = []
 
@@ -255,33 +541,42 @@ def build_posts(event, request=None):
         ref_date = localize(cfp.deadline, event).strftime("%Y-%m-%d")
         for cfp_off in cfp_offsets:
             text, template_ctx = _get_template_for_offset(event, "cfp", cfp_off)
-            text = safe_format(
-                text,
-                event_name=str(event.name),
-                cfp_deadline=deadline_str,
-                cfp_link=cfp_url,
-                hashtags=hashtags,
-            )
             trigger = localize(cfp.deadline - timedelta(days=cfp_off), event)
-            post_id = "cfp"
-            posts.append(
-                {
-                    "id": post_id,
-                    "type": "cfp",
-                    "type_label": TYPE_LABELS["cfp"],
-                    "post_date": trigger.strftime("%Y-%m-%d"),
-                    "post_time": trigger.strftime("%H:%M"),
-                    "post_text": text,
-                    "default_text": text,
-                    "reference_date": ref_date,
-                    "original_post_date": trigger.strftime("%Y-%m-%d"),
-                    "original_post_time": trigger.strftime("%H:%M"),
-                    "event_schedule_display": "N/A",
-                    "is_schedule_associated": False,
-                    "offset_days": cfp_off,
-                    "template_context": template_ctx,
-                }
-            )
+            base_id = "cfp"
+            platform_iter = enabled_platforms if use_platforms else [None]
+            for platform in platform_iter:
+                if platform:
+                    text_formatted = _get_platform_template(event, "cfp", platform, template_ctx)
+                else:
+                    text_formatted = text
+                text_formatted = safe_format(
+                    text_formatted,
+                    event_name=str(event.name),
+                    cfp_deadline=deadline_str,
+                    cfp_link=cfp_url,
+                    hashtags=hashtags,
+                )
+                post_id = f"{base_id}_{platform}" if platform else base_id
+                posts.append(
+                    {
+                        "id": post_id,
+                        "type": "cfp",
+                        "type_label": TYPE_LABELS["cfp"],
+                        "platform": platform,
+                        "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                        "post_date": trigger.strftime("%Y-%m-%d"),
+                        "post_time": trigger.strftime("%H:%M"),
+                        "post_text": text_formatted,
+                        "default_text": text_formatted,
+                        "reference_date": ref_date,
+                        "original_post_date": trigger.strftime("%Y-%m-%d"),
+                        "original_post_time": trigger.strftime("%H:%M"),
+                        "event_schedule_display": "N/A",
+                        "is_schedule_associated": False,
+                        "offset_days": cfp_off,
+                        "template_context": template_ctx,
+                    }
+                )
 
     # ---- Schedule release ------------------------------------------------
     schedule_enabled = event.settings.get(
@@ -293,32 +588,41 @@ def build_posts(event, request=None):
         ref_date = localize(event.date_from, event).strftime("%Y-%m-%d")
         for sched_off in sched_offsets:
             text, template_ctx = _get_template_for_offset(event, "schedule", sched_off)
-            text = safe_format(
-                text,
-                event_name=str(event.name),
-                schedule_link=schedule_url,
-                hashtags=hashtags,
-            )
             trigger = localize(event.date_from - timedelta(days=sched_off), event)
-            post_id = "schedule"
-            posts.append(
-                {
-                    "id": post_id,
-                    "type": "schedule",
-                    "type_label": TYPE_LABELS["schedule"],
-                    "post_date": trigger.strftime("%Y-%m-%d"),
-                    "post_time": trigger.strftime("%H:%M"),
-                    "post_text": text,
-                    "default_text": text,
-                    "reference_date": ref_date,
-                    "original_post_date": trigger.strftime("%Y-%m-%d"),
-                    "original_post_time": trigger.strftime("%H:%M"),
-                    "event_schedule_display": "N/A",
-                    "is_schedule_associated": False,
-                    "offset_days": sched_off,
-                    "template_context": template_ctx,
-                }
-            )
+            base_id = "schedule"
+            platform_iter = enabled_platforms if use_platforms else [None]
+            for platform in platform_iter:
+                if platform:
+                    text_formatted = _get_platform_template(event, "schedule", platform, template_ctx)
+                else:
+                    text_formatted = text
+                text_formatted = safe_format(
+                    text_formatted,
+                    event_name=str(event.name),
+                    schedule_link=schedule_url,
+                    hashtags=hashtags,
+                )
+                post_id = f"{base_id}_{platform}" if platform else base_id
+                posts.append(
+                    {
+                        "id": post_id,
+                        "type": "schedule",
+                        "type_label": TYPE_LABELS["schedule"],
+                        "platform": platform,
+                        "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                        "post_date": trigger.strftime("%Y-%m-%d"),
+                        "post_time": trigger.strftime("%H:%M"),
+                        "post_text": text_formatted,
+                        "default_text": text_formatted,
+                        "reference_date": ref_date,
+                        "original_post_date": trigger.strftime("%Y-%m-%d"),
+                        "original_post_time": trigger.strftime("%H:%M"),
+                        "event_schedule_display": "N/A",
+                        "is_schedule_associated": False,
+                        "offset_days": sched_off,
+                        "template_context": template_ctx,
+                    }
+                )
 
     # ---- Ticket announcements --------------------------------------------
     ticket_enabled = event.settings.get(
@@ -341,34 +645,43 @@ def build_posts(event, request=None):
             ref_date = localize(event.date_from, event).strftime("%Y-%m-%d")
             for tkt_off in tkt_offsets:
                 text, template_ctx = _get_template_for_offset(event, "ticket", tkt_off)
-                text = safe_format(
-                    text,
-                    event_name=str(event.name),
-                    ticket_name=str(ticket.name),
-                    ticket_price=price_str,
-                    ticket_link=event_link,
-                    hashtags=hashtags,
-                )
                 trigger = localize(event.date_from - timedelta(days=tkt_off), event)
-                post_id = f"ticket_{ticket.pk}"
-                posts.append(
-                    {
-                        "id": post_id,
-                        "type": "ticket",
-                        "type_label": TYPE_LABELS["ticket"],
-                        "post_date": trigger.strftime("%Y-%m-%d"),
-                        "post_time": trigger.strftime("%H:%M"),
-                        "post_text": text,
-                        "default_text": text,
-                        "reference_date": ref_date,
-                        "original_post_date": trigger.strftime("%Y-%m-%d"),
-                        "original_post_time": trigger.strftime("%H:%M"),
-                        "event_schedule_display": "N/A",
-                        "is_schedule_associated": False,
-                        "offset_days": tkt_off,
-                        "template_context": template_ctx,
-                    }
-                )
+                base_id = f"ticket_{ticket.pk}"
+                platform_iter = enabled_platforms if use_platforms else [None]
+                for platform in platform_iter:
+                    if platform:
+                        text_formatted = _get_platform_template(event, "ticket", platform, template_ctx)
+                    else:
+                        text_formatted = text
+                    text_formatted = safe_format(
+                        text_formatted,
+                        event_name=str(event.name),
+                        ticket_name=str(ticket.name),
+                        ticket_price=price_str,
+                        ticket_link=event_link,
+                        hashtags=hashtags,
+                    )
+                    post_id = f"{base_id}_{platform}" if platform else base_id
+                    posts.append(
+                        {
+                            "id": post_id,
+                            "type": "ticket",
+                            "type_label": TYPE_LABELS["ticket"],
+                            "platform": platform,
+                            "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                            "post_date": trigger.strftime("%Y-%m-%d"),
+                            "post_time": trigger.strftime("%H:%M"),
+                            "post_text": text_formatted,
+                            "default_text": text_formatted,
+                            "reference_date": ref_date,
+                            "original_post_date": trigger.strftime("%Y-%m-%d"),
+                            "original_post_time": trigger.strftime("%H:%M"),
+                            "event_schedule_display": "N/A",
+                            "is_schedule_associated": False,
+                            "offset_days": tkt_off,
+                            "template_context": template_ctx,
+                        }
+                    )
 
     # ---- Speaker & Session announcements ---------------------------------
     speaker_enabled = event.settings.get(
@@ -407,57 +720,67 @@ def build_posts(event, request=None):
                 talk_start = talk.start if talk else None
 
                 if talk_start:
-                    local_start = localize(talk_start, event)
-                    sched_display = local_start.strftime("%b %d, %Y %H:%M")
+                    base_time = talk_start
+                    sched_display = localize(talk_start, event).strftime("%Y-%m-%d %H:%M")
                 else:
+                    base_time = getattr(event, "date_from", None)
                     sched_display = "Unscheduled"
 
-                # Speaker post (one per unique speaker per offset)
+                # Speaker post
                 if speaker_enabled:
-                    base_time = talk_start or getattr(event, "date_from", None)
-                    if base_time:
-                        for spk_off in spk_offsets:
-                            trigger = localize(
-                                base_time - timedelta(days=spk_off), event
+                    for spk_off in spk_offsets:
+                        trigger = localize(
+                            base_time - timedelta(days=spk_off), event
+                        )
+                        for speaker in sub.speakers.all():
+                            if (speaker.pk, spk_off) in seen_speaker_offsets:
+                                continue
+                            seen_speaker_offsets.add((speaker.pk, spk_off))
+                            if speaker.code:
+                                spk_url = event_absolute_url(
+                                    f"{event.urls.base}speakers/{speaker.code}/",
+                                    request,
+                                )
+                            else:
+                                spk_url = event_link
+                            text, template_ctx = _get_template_for_offset(
+                                event, "speaker", spk_off
                             )
-                            for speaker in sub.speakers.all():
-                                if (speaker.pk, spk_off) in seen_speaker_offsets:
-                                    continue
-                                seen_speaker_offsets.add((speaker.pk, spk_off))
-                                if speaker.code:
-                                    spk_url = event_absolute_url(
-                                        f"{event.urls.base}speakers/{speaker.code}/",
-                                        request,
+                            ref_date = (
+                                localize(base_time, event).strftime("%Y-%m-%d")
+                                if base_time
+                                else None
+                            )
+                            talk_pk = talk.pk if talk else sub.pk
+                            base_id = f"speaker_{speaker.pk}_{talk_pk}"
+                            platform_iter = enabled_platforms if use_platforms else [None]
+                            for platform in platform_iter:
+                                if platform:
+                                    text_formatted = _get_platform_template(
+                                        event, "speaker", platform, template_ctx
                                     )
                                 else:
-                                    spk_url = event_link
-                                text, template_ctx = _get_template_for_offset(
-                                    event, "speaker", spk_off
-                                )
-                                text = safe_format(
-                                    text,
+                                    text_formatted = text
+                                text_formatted = safe_format(
+                                    text_formatted,
                                     event_name=str(event.name),
                                     speaker_name=speaker.get_display_name(),
                                     speaker_link=spk_url,
                                     talk_title=sub.title,
                                     hashtags=hashtags,
                                 )
-                                ref_date = (
-                                    localize(base_time, event).strftime("%Y-%m-%d")
-                                    if base_time
-                                    else None
-                                )
-                                talk_pk = talk.pk if talk else sub.pk
-                                post_id = f"speaker_{speaker.pk}_{talk_pk}"
+                                post_id = f"{base_id}_{platform}" if platform else base_id
                                 posts.append(
                                     {
                                         "id": post_id,
                                         "type": "speaker",
                                         "type_label": TYPE_LABELS["speaker"],
+                                        "platform": platform,
+                                        "platform_label": PLATFORMS.get(platform, "") if platform else "",
                                         "post_date": trigger.strftime("%Y-%m-%d"),
                                         "post_time": trigger.strftime("%H:%M"),
-                                        "post_text": text,
-                                        "default_text": text,
+                                        "post_text": text_formatted,
+                                        "default_text": text_formatted,
                                         "reference_date": ref_date,
                                         "original_post_date": trigger.strftime(
                                             "%Y-%m-%d"
@@ -483,45 +806,59 @@ def build_posts(event, request=None):
                     ref_date = localize(talk_start, event).strftime("%Y-%m-%d")
                     talk_pk = talk.pk if talk else sub.pk
                     for sess_off in sess_offsets:
-                        trigger = localize(
-                            talk_start - timedelta(minutes=sess_off), event
-                        )
+                        if talk_start:
+                            trigger = localize(
+                                talk_start - timedelta(minutes=sess_off), event
+                            )
+                        else:
+                            trigger = localize(base_time - timedelta(days=1), event)
                         text, template_ctx = _get_template_for_offset(
                             event, "session", sess_off
                         )
-                        text = safe_format(
-                            text,
-                            event_name=str(event.name),
-                            talk_title=sub.title,
-                            talk_room=room,
-                            talk_start_time=(
-                                localize(talk_start, event).strftime("%H:%M")
-                                if talk_start
-                                else "TBA"
-                            ),
-                            speaker_names=names,
-                            talk_link=talk_url,
-                            hashtags=hashtags,
-                        )
-                        post_id = f"session_{talk_pk}"
-                        posts.append(
-                            {
-                                "id": post_id,
-                                "type": "session",
-                                "type_label": TYPE_LABELS["session"],
-                                "post_date": trigger.strftime("%Y-%m-%d"),
-                                "post_time": trigger.strftime("%H:%M"),
-                                "post_text": text,
-                                "default_text": text,
-                                "reference_date": ref_date,
-                                "original_post_date": trigger.strftime("%Y-%m-%d"),
-                                "original_post_time": trigger.strftime("%H:%M"),
-                                "event_schedule_display": sched_display,
-                                "is_schedule_associated": True,
-                                "offset_days": sess_off,
-                                "template_context": template_ctx,
-                            }
-                        )
+                        base_id = f"session_{talk_pk}"
+                        platform_iter = enabled_platforms if use_platforms else [None]
+                        for platform in platform_iter:
+                            if platform:
+                                text_formatted = _get_platform_template(
+                                    event, "session", platform, template_ctx
+                                )
+                            else:
+                                text_formatted = text
+                            text_formatted = safe_format(
+                                text_formatted,
+                                event_name=str(event.name),
+                                talk_title=sub.title,
+                                talk_room=room,
+                                talk_start_time=(
+                                    localize(talk_start, event).strftime("%H:%M")
+                                    if talk_start
+                                    else "TBA"
+                                ),
+                                speaker_names=names,
+                                talk_link=talk_url,
+                                hashtags=hashtags,
+                            )
+                            post_id = f"{base_id}_{platform}" if platform else base_id
+                            posts.append(
+                                {
+                                    "id": post_id,
+                                    "type": "session",
+                                    "type_label": TYPE_LABELS["session"],
+                                    "platform": platform,
+                                    "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                                    "post_date": trigger.strftime("%Y-%m-%d"),
+                                    "post_time": trigger.strftime("%H:%M"),
+                                    "post_text": text_formatted,
+                                    "default_text": text_formatted,
+                                    "reference_date": ref_date,
+                                    "original_post_date": trigger.strftime("%Y-%m-%d"),
+                                    "original_post_time": trigger.strftime("%H:%M"),
+                                    "event_schedule_display": sched_display,
+                                    "is_schedule_associated": True,
+                                    "offset_days": sess_off,
+                                    "template_context": template_ctx,
+                                }
+                            )
 
     # Sort chronologically
     posts.sort(key=lambda p: (p["post_date"], p["post_time"]))

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -113,7 +113,8 @@ PLATFORM_DEFAULT_TEMPLATES = {
                 "Deadline {cfp_deadline}. {cfp_link} {hashtags}"
             ),
             "final_call": (
-                "🚨 Last call! Submit to {event_name} by {cfp_deadline}: {cfp_link} {hashtags}"
+                "🚨 Last call! Submit to {event_name} by {cfp_deadline}: "
+                "{cfp_link} {hashtags}"
             ),
         },
         "speaker": {
@@ -152,7 +153,8 @@ PLATFORM_DEFAULT_TEMPLATES = {
                 "⚡ Don't miss {ticket_name} for {event_name}! {ticket_link} {hashtags}"
             ),
             "final_call": (
-                "🔥 Last chance! {ticket_name} for {event_name}. {ticket_link} {hashtags}"
+                "🔥 Last chance! {ticket_name} for {event_name}. "
+                "{ticket_link} {hashtags}"
             ),
         },
         "schedule": {
@@ -208,7 +210,8 @@ PLATFORM_DEFAULT_TEMPLATES = {
                 "More info: {speaker_link}\n{hashtags}"
             ),
             "reminder": (
-                "🗓 *Don't miss* {speaker_name} presenting *'{talk_title}'* at {event_name}!\n"
+                "🗓 *Don't miss* {speaker_name} presenting "
+                "*'{talk_title}'* at {event_name}!\n"
                 "{speaker_link}\n{hashtags}"
             ),
             "final_call": (
@@ -229,7 +232,8 @@ PLATFORM_DEFAULT_TEMPLATES = {
                 "{talk_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 *Starting Now!* *'{talk_title}'* by {speaker_names} in {talk_room}\n"
+                "🔥 *Starting Now!* *'{talk_title}'* by {speaker_names} "
+                "in {talk_room}\n"
                 "Join: {talk_link}\n{hashtags}"
             ),
         },
@@ -253,8 +257,7 @@ PLATFORM_DEFAULT_TEMPLATES = {
                 "Plan your days: {schedule_link}\n{hashtags}"
             ),
             "reminder": (
-                "🗓 *Check the Schedule* — {event_name}\n"
-                "{schedule_link}\n{hashtags}"
+                "🗓 *Check the Schedule* — {event_name}\n{schedule_link}\n{hashtags}"
             ),
         },
     },
@@ -263,12 +266,14 @@ PLATFORM_DEFAULT_TEMPLATES = {
         "cfp": {
             "announcement": (
                 "We're excited to open our Call for Proposals for {event_name}! "
-                "Share your expertise with our community. The submission deadline is {cfp_deadline}. "
+                "Share your expertise with our community. "
+                "The submission deadline is {cfp_deadline}. "
                 "Submit your proposal here: {cfp_link} {hashtags}"
             ),
             "reminder": (
                 "⏰ Reminder: The CFP for {event_name} closes on {cfp_deadline}. "
-                "Don't miss this opportunity to present your ideas. Submit now: {cfp_link} {hashtags}"
+                "Don't miss this opportunity to present your ideas. "
+                "Submit now: {cfp_link} {hashtags}"
             ),
             "final_call": (
                 "Final call! Submissions for {event_name} close on {cfp_deadline}. "
@@ -287,14 +292,17 @@ PLATFORM_DEFAULT_TEMPLATES = {
                 "A session not to be missed! Details: {speaker_link} {hashtags}"
             ),
             "final_call": (
-                "Spotlight: {speaker_name} will be presenting '{talk_title}' at {event_name}. "
+                "Spotlight: {speaker_name} will be presenting '{talk_title}' "
+                "at {event_name}. "
                 "Join us live! {speaker_link} {hashtags}"
             ),
         },
         "session": {
             "announcement": (
-                "Mark your calendars! '{talk_title}' by {speaker_names} is coming up at {event_name}. "
-                "Room: {talk_room} | Time: {talk_start_time}. Full details: {talk_link} {hashtags}"
+                "Mark your calendars! '{talk_title}' by {speaker_names} is "
+                "coming up at {event_name}. "
+                "Room: {talk_room} | Time: {talk_start_time}. "
+                "Full details: {talk_link} {hashtags}"
             ),
             "reminder": (
                 "Session starting soon: '{talk_title}' by {speaker_names} "
@@ -314,7 +322,8 @@ PLATFORM_DEFAULT_TEMPLATES = {
             ),
             "reminder": (
                 "Have you registered for {event_name} yet? "
-                "{ticket_name} tickets ({ticket_price}) are still available: {ticket_link} {hashtags}"
+                "{ticket_name} tickets ({ticket_price}) are still available: "
+                "{ticket_link} {hashtags}"
             ),
             "final_call": (
                 "Last chance to register for {event_name}! "
@@ -546,7 +555,9 @@ def build_posts(event, request=None):
             platform_iter = enabled_platforms if use_platforms else [None]
             for platform in platform_iter:
                 if platform:
-                    text_formatted = _get_platform_template(event, "cfp", platform, template_ctx)
+                    text_formatted = _get_platform_template(
+                        event, "cfp", platform, template_ctx
+                    )
                 else:
                     text_formatted = text
                 text_formatted = safe_format(
@@ -563,7 +574,9 @@ def build_posts(event, request=None):
                         "type": "cfp",
                         "type_label": TYPE_LABELS["cfp"],
                         "platform": platform,
-                        "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                        "platform_label": PLATFORMS.get(platform, "")
+                        if platform
+                        else "",
                         "post_date": trigger.strftime("%Y-%m-%d"),
                         "post_time": trigger.strftime("%H:%M"),
                         "post_text": text_formatted,
@@ -593,7 +606,9 @@ def build_posts(event, request=None):
             platform_iter = enabled_platforms if use_platforms else [None]
             for platform in platform_iter:
                 if platform:
-                    text_formatted = _get_platform_template(event, "schedule", platform, template_ctx)
+                    text_formatted = _get_platform_template(
+                        event, "schedule", platform, template_ctx
+                    )
                 else:
                     text_formatted = text
                 text_formatted = safe_format(
@@ -609,7 +624,9 @@ def build_posts(event, request=None):
                         "type": "schedule",
                         "type_label": TYPE_LABELS["schedule"],
                         "platform": platform,
-                        "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                        "platform_label": PLATFORMS.get(platform, "")
+                        if platform
+                        else "",
                         "post_date": trigger.strftime("%Y-%m-%d"),
                         "post_time": trigger.strftime("%H:%M"),
                         "post_text": text_formatted,
@@ -650,7 +667,9 @@ def build_posts(event, request=None):
                 platform_iter = enabled_platforms if use_platforms else [None]
                 for platform in platform_iter:
                     if platform:
-                        text_formatted = _get_platform_template(event, "ticket", platform, template_ctx)
+                        text_formatted = _get_platform_template(
+                            event, "ticket", platform, template_ctx
+                        )
                     else:
                         text_formatted = text
                     text_formatted = safe_format(
@@ -668,7 +687,9 @@ def build_posts(event, request=None):
                             "type": "ticket",
                             "type_label": TYPE_LABELS["ticket"],
                             "platform": platform,
-                            "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                            "platform_label": PLATFORMS.get(platform, "")
+                            if platform
+                            else "",
                             "post_date": trigger.strftime("%Y-%m-%d"),
                             "post_time": trigger.strftime("%H:%M"),
                             "post_text": text_formatted,
@@ -721,7 +742,9 @@ def build_posts(event, request=None):
 
                 if talk_start:
                     base_time = talk_start
-                    sched_display = localize(talk_start, event).strftime("%Y-%m-%d %H:%M")
+                    sched_display = localize(talk_start, event).strftime(
+                        "%Y-%m-%d %H:%M"
+                    )
                 else:
                     base_time = getattr(event, "date_from", None)
                     sched_display = "Unscheduled"
@@ -729,9 +752,7 @@ def build_posts(event, request=None):
                 # Speaker post
                 if speaker_enabled:
                     for spk_off in spk_offsets:
-                        trigger = localize(
-                            base_time - timedelta(days=spk_off), event
-                        )
+                        trigger = localize(base_time - timedelta(days=spk_off), event)
                         for speaker in sub.speakers.all():
                             if (speaker.pk, spk_off) in seen_speaker_offsets:
                                 continue
@@ -753,7 +774,9 @@ def build_posts(event, request=None):
                             )
                             talk_pk = talk.pk if talk else sub.pk
                             base_id = f"speaker_{speaker.pk}_{talk_pk}"
-                            platform_iter = enabled_platforms if use_platforms else [None]
+                            platform_iter = (
+                                enabled_platforms if use_platforms else [None]
+                            )
                             for platform in platform_iter:
                                 if platform:
                                     text_formatted = _get_platform_template(
@@ -769,14 +792,18 @@ def build_posts(event, request=None):
                                     talk_title=sub.title,
                                     hashtags=hashtags,
                                 )
-                                post_id = f"{base_id}_{platform}" if platform else base_id
+                                post_id = (
+                                    f"{base_id}_{platform}" if platform else base_id
+                                )
                                 posts.append(
                                     {
                                         "id": post_id,
                                         "type": "speaker",
                                         "type_label": TYPE_LABELS["speaker"],
                                         "platform": platform,
-                                        "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                                        "platform_label": PLATFORMS.get(platform, "")
+                                        if platform
+                                        else "",
                                         "post_date": trigger.strftime("%Y-%m-%d"),
                                         "post_time": trigger.strftime("%H:%M"),
                                         "post_text": text_formatted,
@@ -845,7 +872,9 @@ def build_posts(event, request=None):
                                     "type": "session",
                                     "type_label": TYPE_LABELS["session"],
                                     "platform": platform,
-                                    "platform_label": PLATFORMS.get(platform, "") if platform else "",
+                                    "platform_label": PLATFORMS.get(platform, "")
+                                    if platform
+                                    else "",
                                     "post_date": trigger.strftime("%Y-%m-%d"),
                                     "post_time": trigger.strftime("%H:%M"),
                                     "post_text": text_formatted,
@@ -955,7 +984,9 @@ def generate_csv_from_posts(posts, format="generic"):
                 # Buffer expects date and time combined (e.g., "YYYY-MM-DD HH:MM")
                 date = post.get("post_date", "")
                 time = post.get("post_time", "")
-                scheduled_at = f"{date} {time}".strip() if date and time else (date or time)
+                scheduled_at = (
+                    f"{date} {time}".strip() if date and time else (date or time)
+                )
                 writer.writerow(
                     [
                         post.get("post_text", ""),
@@ -990,4 +1021,3 @@ def generate_csv_from_posts(posts, format="generic"):
                 )
 
     return output.getvalue()
-

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -926,23 +926,68 @@ def sync_posts_to_db(event, request=None):
 # ---------------------------------------------------------------------------
 
 
-def generate_csv_from_posts(posts):
+def generate_csv_from_posts(posts, format="generic"):
     """
     Accept a list of post dicts (already edited/filtered by the user in the UI)
-    and return a CSV string ready for import into social media scheduling tools.
+    and return a CSV string ready for import into social media scheduling tools,
+    formatted according to the selected format preset.
     Only rows where enabled=True are included.
     """
     output = io.StringIO()
     writer = csv.writer(output)
-    writer.writerow(["post_date", "post_time", "post_text", "media_url"])
-    for post in posts:
-        if post.get("enabled", True):
-            writer.writerow(
-                [
-                    post.get("post_date", ""),
-                    post.get("post_time", ""),
-                    post.get("post_text", ""),
-                    post.get("media_url", ""),
-                ]
-            )
+
+    if format == "postiz":
+        writer.writerow(["content", "date", "time", "media"])
+        for post in posts:
+            if post.get("enabled", True):
+                writer.writerow(
+                    [
+                        post.get("post_text", ""),
+                        post.get("post_date", ""),
+                        post.get("post_time", ""),
+                        post.get("media_url", ""),
+                    ]
+                )
+    elif format == "buffer":
+        writer.writerow(["text", "scheduled_at", "link", "image"])
+        for post in posts:
+            if post.get("enabled", True):
+                # Buffer expects date and time combined (e.g., "YYYY-MM-DD HH:MM")
+                date = post.get("post_date", "")
+                time = post.get("post_time", "")
+                scheduled_at = f"{date} {time}".strip() if date and time else (date or time)
+                writer.writerow(
+                    [
+                        post.get("post_text", ""),
+                        scheduled_at,
+                        "",  # link placeholder
+                        post.get("media_url", ""),
+                    ]
+                )
+    elif format == "hootsuite":
+        writer.writerow(["date", "time", "text", "link"])
+        for post in posts:
+            if post.get("enabled", True):
+                writer.writerow(
+                    [
+                        post.get("post_date", ""),
+                        post.get("post_time", ""),
+                        post.get("post_text", ""),
+                        post.get("media_url", ""),  # link maps to media_url
+                    ]
+                )
+    else:  # generic
+        writer.writerow(["post_date", "post_time", "post_text", "media_url"])
+        for post in posts:
+            if post.get("enabled", True):
+                writer.writerow(
+                    [
+                        post.get("post_date", ""),
+                        post.get("post_time", ""),
+                        post.get("post_text", ""),
+                        post.get("media_url", ""),
+                    ]
+                )
+
     return output.getvalue()
+

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -91,9 +91,9 @@ DEFAULT_TEMPLATES = {
 
 PLATFORMS = {
     "twitter": "X / Twitter",
-    "mastodon": "Mastodon",
-    "telegram": "Telegram",
     "linkedin": "LinkedIn",
+    "telegram": "Telegram",
+    "mastodon": "Mastodon",
 }
 
 # Platform-specific default template overrides.
@@ -182,10 +182,66 @@ PLATFORM_DEFAULT_TEMPLATES = {
                 "Submit now: {cfp_link} {hashtags}"
             ),
         },
-        "speaker": DEFAULT_TEMPLATES["speaker"],
-        "session": DEFAULT_TEMPLATES["session"],
-        "ticket": DEFAULT_TEMPLATES["ticket"],
-        "schedule": DEFAULT_TEMPLATES["schedule"],
+        "speaker": {
+            "announcement": (
+                "🎤 Speaker announcement for {event_name}!\n"
+                "{speaker_name} will present '{talk_title}'.\n"
+                "Learn more: {speaker_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "🗓 Reminder: {speaker_name} is presenting '{talk_title}' "
+                "at {event_name}!\n"
+                "Details: {speaker_link}\n{hashtags}"
+            ),
+            "final_call": (
+                "🔥 Starting soon! Catch {speaker_name} presenting "
+                "'{talk_title}' at {event_name}.\n"
+                "{speaker_link}\n{hashtags}"
+            ),
+        },
+        "session": {
+            "announcement": (
+                "🗓 Upcoming session at {event_name}:\n"
+                "'{talk_title}' by {speaker_names}\n"
+                "Room: {talk_room} | Time: {talk_start_time}\n"
+                "Full info: {talk_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "⏰ Session starting soon at {event_name}:\n"
+                "'{talk_title}' by {speaker_names} at {talk_start_time}\n"
+                "{talk_link}\n{hashtags}"
+            ),
+            "final_call": (
+                "🔥 Starting now! '{talk_title}' by {speaker_names} "
+                "in {talk_room}.\n"
+                "Join: {talk_link}\n{hashtags}"
+            ),
+        },
+        "ticket": {
+            "announcement": (
+                "🎟 Tickets now available for {event_name}!\n"
+                "{ticket_name} — {ticket_price}\n"
+                "Register: {ticket_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "⚡ Still time to register for {event_name}!\n"
+                "{ticket_name}: {ticket_link}\n{hashtags}"
+            ),
+            "final_call": (
+                "🔥 Last chance! Grab your {ticket_name} ticket for "
+                "{event_name}: {ticket_link}\n{hashtags}"
+            ),
+        },
+        "schedule": {
+            "announcement": (
+                "📅 The {event_name} schedule is live!\n"
+                "Browse sessions and plan your days: {schedule_link}\n{hashtags}"
+            ),
+            "reminder": (
+                "🗓 Have you checked the {event_name} schedule?\n"
+                "{schedule_link}\n{hashtags}"
+            ),
+        },
     },
     "telegram": {
         # Telegram supports Markdown; use bold via *text*

--- a/socialmedia/forms.py
+++ b/socialmedia/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.forms import SettingsForm
 
-from .export import DEFAULT_TEMPLATES, PLATFORMS
+from .export import DEFAULT_TEMPLATES
 
 MAX_OFFSETS = 10
 MAX_OFFSET_VALUE_CFP = 365
@@ -84,9 +84,7 @@ class SocialMediaSettingsForm(SettingsForm):
     )
     socialmedia_mastodon_enabled = forms.BooleanField(
         label=_("Enable Mastodon"),
-        help_text=_(
-            "Generate separate draft posts for Mastodon (≤500 chars)."
-        ),
+        help_text=_("Generate separate draft posts for Mastodon (≤500 chars)."),
         required=False,
         initial=False,
     )
@@ -151,7 +149,8 @@ class SocialMediaSettingsForm(SettingsForm):
         widget=forms.Textarea(attrs={"rows": 2}),
         required=False,
         help_text=_(
-            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+            "Available: {event_name}, {speaker_name}, {speaker_link}, "
+            "{talk_title}, {hashtags}"
         ),
     )
     socialmedia_mastodon_speaker_template = forms.CharField(
@@ -159,7 +158,8 @@ class SocialMediaSettingsForm(SettingsForm):
         widget=forms.Textarea(attrs={"rows": 2}),
         required=False,
         help_text=_(
-            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+            "Available: {event_name}, {speaker_name}, {speaker_link}, "
+            "{talk_title}, {hashtags}"
         ),
     )
     socialmedia_telegram_speaker_template = forms.CharField(
@@ -168,7 +168,8 @@ class SocialMediaSettingsForm(SettingsForm):
         required=False,
         help_text=_(
             "Markdown supported. "
-            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+            "Available: {event_name}, {speaker_name}, {speaker_link}, "
+            "{talk_title}, {hashtags}"
         ),
     )
     socialmedia_linkedin_speaker_template = forms.CharField(
@@ -176,7 +177,8 @@ class SocialMediaSettingsForm(SettingsForm):
         widget=forms.Textarea(attrs={"rows": 3}),
         required=False,
         help_text=_(
-            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+            "Available: {event_name}, {speaker_name}, {speaker_link}, "
+            "{talk_title}, {hashtags}"
         ),
     )
 
@@ -225,7 +227,8 @@ class SocialMediaSettingsForm(SettingsForm):
         widget=forms.Textarea(attrs={"rows": 2}),
         required=False,
         help_text=_(
-            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+            "Available: {event_name}, {ticket_name}, {ticket_price}, "
+            "{ticket_link}, {hashtags}"
         ),
     )
     socialmedia_mastodon_ticket_template = forms.CharField(
@@ -233,7 +236,8 @@ class SocialMediaSettingsForm(SettingsForm):
         widget=forms.Textarea(attrs={"rows": 2}),
         required=False,
         help_text=_(
-            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+            "Available: {event_name}, {ticket_name}, {ticket_price}, "
+            "{ticket_link}, {hashtags}"
         ),
     )
     socialmedia_telegram_ticket_template = forms.CharField(
@@ -242,7 +246,8 @@ class SocialMediaSettingsForm(SettingsForm):
         required=False,
         help_text=_(
             "Markdown supported. "
-            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+            "Available: {event_name}, {ticket_name}, {ticket_price}, "
+            "{ticket_link}, {hashtags}"
         ),
     )
     socialmedia_linkedin_ticket_template = forms.CharField(
@@ -250,7 +255,8 @@ class SocialMediaSettingsForm(SettingsForm):
         widget=forms.Textarea(attrs={"rows": 3}),
         required=False,
         help_text=_(
-            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+            "Available: {event_name}, {ticket_name}, {ticket_price}, "
+            "{ticket_link}, {hashtags}"
         ),
     )
 
@@ -259,17 +265,13 @@ class SocialMediaSettingsForm(SettingsForm):
         label=_("X / Twitter — Schedule template"),
         widget=forms.Textarea(attrs={"rows": 2}),
         required=False,
-        help_text=_(
-            "Available: {event_name}, {schedule_link}, {hashtags}"
-        ),
+        help_text=_("Available: {event_name}, {schedule_link}, {hashtags}"),
     )
     socialmedia_mastodon_schedule_template = forms.CharField(
         label=_("Mastodon — Schedule template"),
         widget=forms.Textarea(attrs={"rows": 2}),
         required=False,
-        help_text=_(
-            "Available: {event_name}, {schedule_link}, {hashtags}"
-        ),
+        help_text=_("Available: {event_name}, {schedule_link}, {hashtags}"),
     )
     socialmedia_telegram_schedule_template = forms.CharField(
         label=_("Telegram — Schedule template"),
@@ -283,9 +285,7 @@ class SocialMediaSettingsForm(SettingsForm):
         label=_("LinkedIn — Schedule template"),
         widget=forms.Textarea(attrs={"rows": 3}),
         required=False,
-        help_text=_(
-            "Available: {event_name}, {schedule_link}, {hashtags}"
-        ),
+        help_text=_("Available: {event_name}, {schedule_link}, {hashtags}"),
     )
 
     # ------------------------------------------------------------------

--- a/socialmedia/forms.py
+++ b/socialmedia/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.forms import SettingsForm
 
-from .export import DEFAULT_TEMPLATES
+from .export import DEFAULT_TEMPLATES, PLATFORMS
 
 MAX_OFFSETS = 10
 MAX_OFFSET_VALUE_CFP = 365
@@ -10,6 +10,46 @@ MAX_OFFSET_VALUE_SPEAKER = 365
 MAX_OFFSET_VALUE_SESSION = 1440
 MAX_OFFSET_VALUE_TICKET = 365
 MAX_OFFSET_VALUE_SCHEDULE = 90
+
+# Display order for platforms in the UI
+PLATFORM_ORDER = ["twitter", "linkedin", "telegram", "mastodon"]
+
+# Character limits per platform (None means no enforced limit)
+PLATFORM_CHAR_LIMITS = {
+    "twitter": 280,
+    "mastodon": 500,
+    "telegram": None,
+    "linkedin": None,
+}
+
+# Extra help-text hints per platform
+_PLATFORM_HINTS = {
+    "twitter": "≤280 chars.",
+    "mastodon": "≤500 chars.",
+    "telegram": "Markdown supported.",
+    "linkedin": "Professional tone.",
+}
+
+# Available placeholder tokens per post type
+_TYPE_TOKENS = {
+    "cfp": "{event_name}, {cfp_deadline}, {cfp_link}, {hashtags}",
+    "speaker": "{event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}",
+    "session": (
+        "{event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
+        "{speaker_names}, {talk_link}, {hashtags}"
+    ),
+    "ticket": "{event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}",
+    "schedule": "{event_name}, {schedule_link}, {hashtags}",
+}
+
+# Human-readable post-type labels
+_TYPE_LABELS = {
+    "cfp": "CFP",
+    "speaker": "Speaker",
+    "session": "Session",
+    "ticket": "Ticket",
+    "schedule": "Schedule",
+}
 
 
 def _validate_offsets(value, max_value, unit_label="days"):
@@ -49,6 +89,30 @@ def _validate_offsets(value, max_value, unit_label="days"):
     return ", ".join(str(v) for v in sorted(cleaned, reverse=True))
 
 
+def _check_platform_char_limit(value, limit, platform_name):
+    """Raise ValidationError if the template text (excluding {token} placeholders)
+    already exceeds the platform character limit."""
+    import re
+
+    if not value or not limit:
+        return value
+    stripped = re.sub(r"\{[^}]+\}", "", value)
+    if len(stripped) > limit:
+        raise forms.ValidationError(
+            _(
+                "The template text (excluding placeholders) is %(length)s characters, "
+                "which already exceeds the %(platform)s limit of %(limit)s characters. "
+                "Shorten the template so interpolated posts fit within the limit."
+            ),
+            params={
+                "length": len(stripped),
+                "platform": platform_name,
+                "limit": limit,
+            },
+        )
+    return value
+
+
 class SocialMediaSettingsForm(SettingsForm):
     # ------------------------------------------------------------------
     # Global settings
@@ -72,26 +136,12 @@ class SocialMediaSettingsForm(SettingsForm):
     )
 
     # ------------------------------------------------------------------
-    # Platform toggles
+    # Platform toggles  (order: Twitter, LinkedIn, Telegram, Mastodon)
     # ------------------------------------------------------------------
     socialmedia_twitter_enabled = forms.BooleanField(
         label=_("Enable X / Twitter"),
         help_text=_(
             "Generate separate draft posts optimised for X / Twitter (≤280 chars)."
-        ),
-        required=False,
-        initial=False,
-    )
-    socialmedia_mastodon_enabled = forms.BooleanField(
-        label=_("Enable Mastodon"),
-        help_text=_("Generate separate draft posts for Mastodon (≤500 chars)."),
-        required=False,
-        initial=False,
-    )
-    socialmedia_telegram_enabled = forms.BooleanField(
-        label=_("Enable Telegram"),
-        help_text=_(
-            "Generate separate draft posts for Telegram (Markdown formatting)."
         ),
         required=False,
         initial=False,
@@ -104,189 +154,23 @@ class SocialMediaSettingsForm(SettingsForm):
         required=False,
         initial=False,
     )
-
-    # Per-platform template overrides for CFP
-    socialmedia_twitter_cfp_template = forms.CharField(
-        label=_("X / Twitter — CFP template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
+    socialmedia_telegram_enabled = forms.BooleanField(
+        label=_("Enable Telegram"),
         help_text=_(
-            "Leave blank to use the Twitter-specific default. "
-            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
+            "Generate separate draft posts for Telegram (Markdown formatting)."
         ),
+        required=False,
+        initial=False,
     )
-    socialmedia_mastodon_cfp_template = forms.CharField(
-        label=_("Mastodon — CFP template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
+    socialmedia_mastodon_enabled = forms.BooleanField(
+        label=_("Enable Mastodon"),
+        help_text=_("Generate separate draft posts for Mastodon (≤500 chars)."),
         required=False,
-        help_text=_(
-            "Leave blank to use the Mastodon-specific default. "
-            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
-        ),
-    )
-    socialmedia_telegram_cfp_template = forms.CharField(
-        label=_("Telegram — CFP template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Leave blank to use the Telegram-specific default (Markdown supported). "
-            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
-        ),
-    )
-    socialmedia_linkedin_cfp_template = forms.CharField(
-        label=_("LinkedIn — CFP template"),
-        widget=forms.Textarea(attrs={"rows": 3}),
-        required=False,
-        help_text=_(
-            "Leave blank to use the LinkedIn-specific default. "
-            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
-        ),
+        initial=False,
     )
 
-    # Per-platform template overrides for Speaker
-    socialmedia_twitter_speaker_template = forms.CharField(
-        label=_("X / Twitter — Speaker template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {speaker_name}, {speaker_link}, "
-            "{talk_title}, {hashtags}"
-        ),
-    )
-    socialmedia_mastodon_speaker_template = forms.CharField(
-        label=_("Mastodon — Speaker template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {speaker_name}, {speaker_link}, "
-            "{talk_title}, {hashtags}"
-        ),
-    )
-    socialmedia_telegram_speaker_template = forms.CharField(
-        label=_("Telegram — Speaker template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Markdown supported. "
-            "Available: {event_name}, {speaker_name}, {speaker_link}, "
-            "{talk_title}, {hashtags}"
-        ),
-    )
-    socialmedia_linkedin_speaker_template = forms.CharField(
-        label=_("LinkedIn — Speaker template"),
-        widget=forms.Textarea(attrs={"rows": 3}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {speaker_name}, {speaker_link}, "
-            "{talk_title}, {hashtags}"
-        ),
-    )
-
-    # Per-platform template overrides for Session
-    socialmedia_twitter_session_template = forms.CharField(
-        label=_("X / Twitter — Session template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
-            "{speaker_names}, {talk_link}, {hashtags}"
-        ),
-    )
-    socialmedia_mastodon_session_template = forms.CharField(
-        label=_("Mastodon — Session template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
-            "{speaker_names}, {talk_link}, {hashtags}"
-        ),
-    )
-    socialmedia_telegram_session_template = forms.CharField(
-        label=_("Telegram — Session template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Markdown supported. "
-            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
-            "{speaker_names}, {talk_link}, {hashtags}"
-        ),
-    )
-    socialmedia_linkedin_session_template = forms.CharField(
-        label=_("LinkedIn — Session template"),
-        widget=forms.Textarea(attrs={"rows": 3}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
-            "{speaker_names}, {talk_link}, {hashtags}"
-        ),
-    )
-
-    # Per-platform template overrides for Ticket
-    socialmedia_twitter_ticket_template = forms.CharField(
-        label=_("X / Twitter — Ticket template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {ticket_name}, {ticket_price}, "
-            "{ticket_link}, {hashtags}"
-        ),
-    )
-    socialmedia_mastodon_ticket_template = forms.CharField(
-        label=_("Mastodon — Ticket template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {ticket_name}, {ticket_price}, "
-            "{ticket_link}, {hashtags}"
-        ),
-    )
-    socialmedia_telegram_ticket_template = forms.CharField(
-        label=_("Telegram — Ticket template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Markdown supported. "
-            "Available: {event_name}, {ticket_name}, {ticket_price}, "
-            "{ticket_link}, {hashtags}"
-        ),
-    )
-    socialmedia_linkedin_ticket_template = forms.CharField(
-        label=_("LinkedIn — Ticket template"),
-        widget=forms.Textarea(attrs={"rows": 3}),
-        required=False,
-        help_text=_(
-            "Available: {event_name}, {ticket_name}, {ticket_price}, "
-            "{ticket_link}, {hashtags}"
-        ),
-    )
-
-    # Per-platform template overrides for Schedule
-    socialmedia_twitter_schedule_template = forms.CharField(
-        label=_("X / Twitter — Schedule template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_("Available: {event_name}, {schedule_link}, {hashtags}"),
-    )
-    socialmedia_mastodon_schedule_template = forms.CharField(
-        label=_("Mastodon — Schedule template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_("Available: {event_name}, {schedule_link}, {hashtags}"),
-    )
-    socialmedia_telegram_schedule_template = forms.CharField(
-        label=_("Telegram — Schedule template"),
-        widget=forms.Textarea(attrs={"rows": 2}),
-        required=False,
-        help_text=_(
-            "Markdown supported. Available: {event_name}, {schedule_link}, {hashtags}"
-        ),
-    )
-    socialmedia_linkedin_schedule_template = forms.CharField(
-        label=_("LinkedIn — Schedule template"),
-        widget=forms.Textarea(attrs={"rows": 3}),
-        required=False,
-        help_text=_("Available: {event_name}, {schedule_link}, {hashtags}"),
-    )
+    # Per-platform × per-type template fields are generated dynamically
+    # in __init__() below via PLATFORM_ORDER × _TYPE_LABELS.
 
     # ------------------------------------------------------------------
     # CFP
@@ -494,3 +378,66 @@ class SocialMediaSettingsForm(SettingsForm):
             MAX_OFFSET_VALUE_SCHEDULE,
             "days",
         )
+
+    # ------------------------------------------------------------------
+    # Dynamic per-platform template field generation
+    # ------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Generate per-platform × per-type template fields.
+        # Field order follows PLATFORM_ORDER × _TYPE_LABELS.
+        for platform in PLATFORM_ORDER:
+            platform_label = PLATFORMS[platform]
+            hint = _PLATFORM_HINTS.get(platform, "")
+            rows = 3 if platform == "linkedin" else 2
+            for post_type, type_label in _TYPE_LABELS.items():
+                tokens = _TYPE_TOKENS[post_type]
+                field_name = f"socialmedia_{platform}_{post_type}_template"
+                help_parts = [
+                    f"Leave blank to use the {platform_label}-specific default."
+                ]
+                if hint:
+                    help_parts.append(hint)
+                help_parts.append(f"Available: {tokens}")
+                self.fields[field_name] = forms.CharField(
+                    label=f"{platform_label} \u2014 {type_label} template",
+                    widget=forms.Textarea(attrs={"rows": rows}),
+                    required=False,
+                    help_text=" ".join(help_parts),
+                )
+
+    # ------------------------------------------------------------------
+    # Per-platform character limit validation (helper, called by generated methods)
+    # ------------------------------------------------------------------
+    def _clean_platform_template(self, field_name, platform):
+        value = self.cleaned_data.get(field_name, "")
+        limit = PLATFORM_CHAR_LIMITS.get(platform)
+        platform_label = PLATFORMS.get(platform, platform)
+        return _check_platform_char_limit(value, limit, platform_label)
+
+
+def _add_platform_clean_methods():
+    """Dynamically attach clean_<field>() methods to SocialMediaSettingsForm
+    for all platform × type combinations that have a character limit."""
+    for platform in PLATFORM_ORDER:
+        if PLATFORM_CHAR_LIMITS.get(platform) is None:
+            continue
+        for post_type in _TYPE_LABELS:
+            field_name = f"socialmedia_{platform}_{post_type}_template"
+            method_name = f"clean_{field_name}"
+
+            def _make_cleaner(fn, pl):
+                def cleaner(self):
+                    return self._clean_platform_template(fn, pl)
+
+                cleaner.__name__ = f"clean_{fn}"
+                return cleaner
+
+            setattr(
+                SocialMediaSettingsForm,
+                method_name,
+                _make_cleaner(field_name, platform),
+            )
+
+
+_add_platform_clean_methods()

--- a/socialmedia/forms.py
+++ b/socialmedia/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.forms import SettingsForm
 
-from .export import DEFAULT_TEMPLATES
+from .export import DEFAULT_TEMPLATES, PLATFORMS
 
 MAX_OFFSETS = 10
 MAX_OFFSET_VALUE_CFP = 365
@@ -69,6 +69,223 @@ class SocialMediaSettingsForm(SettingsForm):
         ),
         required=False,
         max_length=200,
+    )
+
+    # ------------------------------------------------------------------
+    # Platform toggles
+    # ------------------------------------------------------------------
+    socialmedia_twitter_enabled = forms.BooleanField(
+        label=_("Enable X / Twitter"),
+        help_text=_(
+            "Generate separate draft posts optimised for X / Twitter (≤280 chars)."
+        ),
+        required=False,
+        initial=False,
+    )
+    socialmedia_mastodon_enabled = forms.BooleanField(
+        label=_("Enable Mastodon"),
+        help_text=_(
+            "Generate separate draft posts for Mastodon (≤500 chars)."
+        ),
+        required=False,
+        initial=False,
+    )
+    socialmedia_telegram_enabled = forms.BooleanField(
+        label=_("Enable Telegram"),
+        help_text=_(
+            "Generate separate draft posts for Telegram (Markdown formatting)."
+        ),
+        required=False,
+        initial=False,
+    )
+    socialmedia_linkedin_enabled = forms.BooleanField(
+        label=_("Enable LinkedIn"),
+        help_text=_(
+            "Generate separate draft posts for LinkedIn (long-form, professional tone)."
+        ),
+        required=False,
+        initial=False,
+    )
+
+    # Per-platform template overrides for CFP
+    socialmedia_twitter_cfp_template = forms.CharField(
+        label=_("X / Twitter — CFP template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Leave blank to use the Twitter-specific default. "
+            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
+        ),
+    )
+    socialmedia_mastodon_cfp_template = forms.CharField(
+        label=_("Mastodon — CFP template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Leave blank to use the Mastodon-specific default. "
+            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
+        ),
+    )
+    socialmedia_telegram_cfp_template = forms.CharField(
+        label=_("Telegram — CFP template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Leave blank to use the Telegram-specific default (Markdown supported). "
+            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
+        ),
+    )
+    socialmedia_linkedin_cfp_template = forms.CharField(
+        label=_("LinkedIn — CFP template"),
+        widget=forms.Textarea(attrs={"rows": 3}),
+        required=False,
+        help_text=_(
+            "Leave blank to use the LinkedIn-specific default. "
+            "Available: {event_name}, {cfp_deadline}, {cfp_link}, {hashtags}"
+        ),
+    )
+
+    # Per-platform template overrides for Speaker
+    socialmedia_twitter_speaker_template = forms.CharField(
+        label=_("X / Twitter — Speaker template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+        ),
+    )
+    socialmedia_mastodon_speaker_template = forms.CharField(
+        label=_("Mastodon — Speaker template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+        ),
+    )
+    socialmedia_telegram_speaker_template = forms.CharField(
+        label=_("Telegram — Speaker template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Markdown supported. "
+            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+        ),
+    )
+    socialmedia_linkedin_speaker_template = forms.CharField(
+        label=_("LinkedIn — Speaker template"),
+        widget=forms.Textarea(attrs={"rows": 3}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {speaker_name}, {speaker_link}, {talk_title}, {hashtags}"
+        ),
+    )
+
+    # Per-platform template overrides for Session
+    socialmedia_twitter_session_template = forms.CharField(
+        label=_("X / Twitter — Session template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
+            "{speaker_names}, {talk_link}, {hashtags}"
+        ),
+    )
+    socialmedia_mastodon_session_template = forms.CharField(
+        label=_("Mastodon — Session template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
+            "{speaker_names}, {talk_link}, {hashtags}"
+        ),
+    )
+    socialmedia_telegram_session_template = forms.CharField(
+        label=_("Telegram — Session template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Markdown supported. "
+            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
+            "{speaker_names}, {talk_link}, {hashtags}"
+        ),
+    )
+    socialmedia_linkedin_session_template = forms.CharField(
+        label=_("LinkedIn — Session template"),
+        widget=forms.Textarea(attrs={"rows": 3}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {talk_title}, {talk_room}, {talk_start_time}, "
+            "{speaker_names}, {talk_link}, {hashtags}"
+        ),
+    )
+
+    # Per-platform template overrides for Ticket
+    socialmedia_twitter_ticket_template = forms.CharField(
+        label=_("X / Twitter — Ticket template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+        ),
+    )
+    socialmedia_mastodon_ticket_template = forms.CharField(
+        label=_("Mastodon — Ticket template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+        ),
+    )
+    socialmedia_telegram_ticket_template = forms.CharField(
+        label=_("Telegram — Ticket template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Markdown supported. "
+            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+        ),
+    )
+    socialmedia_linkedin_ticket_template = forms.CharField(
+        label=_("LinkedIn — Ticket template"),
+        widget=forms.Textarea(attrs={"rows": 3}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {ticket_name}, {ticket_price}, {ticket_link}, {hashtags}"
+        ),
+    )
+
+    # Per-platform template overrides for Schedule
+    socialmedia_twitter_schedule_template = forms.CharField(
+        label=_("X / Twitter — Schedule template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {schedule_link}, {hashtags}"
+        ),
+    )
+    socialmedia_mastodon_schedule_template = forms.CharField(
+        label=_("Mastodon — Schedule template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {schedule_link}, {hashtags}"
+        ),
+    )
+    socialmedia_telegram_schedule_template = forms.CharField(
+        label=_("Telegram — Schedule template"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        help_text=_(
+            "Markdown supported. Available: {event_name}, {schedule_link}, {hashtags}"
+        ),
+    )
+    socialmedia_linkedin_schedule_template = forms.CharField(
+        label=_("LinkedIn — Schedule template"),
+        widget=forms.Textarea(attrs={"rows": 3}),
+        required=False,
+        help_text=_(
+            "Available: {event_name}, {schedule_link}, {hashtags}"
+        ),
     )
 
     # ------------------------------------------------------------------

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -935,3 +935,16 @@ body .sm-toast i {
 .skeleton-row td:nth-child(6) .skeleton-bar {
   width: 30px;
 }
+
+/* Named skeleton column helpers (match HTML class names) */
+.skeleton-bar.skeleton-col-check {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+}
+.skeleton-bar.skeleton-col-type    { width: 60px; }
+.skeleton-bar.skeleton-col-platform { width: 80px; }
+.skeleton-bar.skeleton-col-date    { width: 110px; }
+.skeleton-bar.skeleton-col-postdate { width: 125px; }
+.skeleton-bar.skeleton-col-content { width: 100%; }
+.skeleton-bar.skeleton-col-actions { width: 30px; }

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -446,28 +446,21 @@
 
 /* ---- Export button bar ---- */
 .export-bar {
-  position: sticky;
-  bottom: 0;
-  background: rgba(255, 255, 255, .95);
-  backdrop-filter: blur(4px);
-  border-top: 1px solid #e4e4e4;
-  padding: 12px 0;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 10px;
-  z-index: 100;
-  margin: 0 -15px;
-  padding-left: 15px;
-  padding-right: 15px;
+  padding: 10px 0;
+  margin-top: 8px;
 }
 
 .export-bar .selected-count {
   font-size: 13px;
   color: #666;
+  margin-right: auto;
 }
 
 .export-bar .btn-export {
-  margin-left: auto;
 }
 
 /* Time input styling to ensure AM/PM and clock picker are fully visible */

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -187,7 +187,44 @@
   color: #7a6000;
 }
 
-/* Date/time cell */
+/* Platform badge */
+.platform-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 9px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.plat-twitter {
+  background: #e8f6ff;
+  color: #1a8cd8;
+}
+
+.plat-mastodon {
+  background: #ede8ff;
+  color: #6364ff;
+}
+
+.plat-telegram {
+  background: #e8f7ff;
+  color: #0088cc;
+}
+
+.plat-linkedin {
+  background: #e8f0fb;
+  color: #0077b5;
+}
+
+.plat-generic {
+  background: #f2f2f2;
+  color: #777;
+}
+
+
 .dt-cell {
   white-space: nowrap;
 }
@@ -355,6 +392,37 @@
   display: flex;
   align-items: center;
   gap: 6px;
+}
+
+.adv-group-desc {
+  font-size: 12px;
+  color: #777;
+  margin: -6px 0 12px;
+  line-height: 1.5;
+}
+
+.platform-toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.platform-block {
+  border: 1px solid #e8e8e8;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.platform-block-header {
+  padding: 4px 0;
+}
+
+.platform-block-templates {
+  border-top: 1px solid #f0f0f0;
+  padding: 8px 0 0;
+  background: #fafafa;
 }
 
 .default-template-preview {

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -741,6 +741,17 @@ body .sm-toast i {
   flex-wrap: wrap;
 }
 
+.char-count.has-warning {
+  color: #d9534f;
+  font-weight: 700;
+}
+
+.post-text-edit.has-error {
+  border-color: #d9534f;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(217, 83, 79, .6);
+}
+
+
 /* ---- Validation alert banner ---- */
 .sm-validation-alert {
   margin-bottom: 12px;

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -25,6 +25,14 @@
     linkedin: { label: "LinkedIn",    iconClass: "fa fa-linkedin",   colorClass: "plat-linkedin" },
   };
 
+  const PLATFORM_LIMITS = {
+    twitter: 280,
+    mastodon: 500,
+    telegram: 4096,
+    linkedin: 3000
+  };
+
+
   // ---- Helper functions ----
   const Helpers = {
     addDays(dateStr, days) {
@@ -119,15 +127,19 @@
       validate() {
         let pastCount = 0;
         let placeholderCount = 0;
+        let limitExceededCount = 0;
         const todayStr = Helpers.getLocalTodayStr();
 
         posts.forEach(p => {
           if (!p.enabled) return;
           if (p.post_date < todayStr) pastCount++;
           if (p.post_text.includes("{") || p.post_text.includes("}")) placeholderCount++;
+
+          const limit = PLATFORM_LIMITS[p.platform] || null;
+          if (limit && p.post_text.length > limit) limitExceededCount++;
         });
 
-        return { pastCount, placeholderCount };
+        return { pastCount, placeholderCount, limitExceededCount };
       }
     };
   })();
@@ -156,7 +168,7 @@
         return r.text();
       });
     },
-    exportCSV(posts) {
+    exportCSV(posts, format) {
       return fetch(Config.EXPORT_URL, {
         method: "POST",
         headers: {
@@ -164,7 +176,7 @@
           "X-CSRFToken": Config.CSRF_TOKEN,
           "X-Requested-With": "XMLHttpRequest",
         },
-        body: JSON.stringify({ posts })
+        body: JSON.stringify({ posts, format })
       }).then(r => {
         if (!r.ok) throw new Error(`Export failed: ${r.status}`);
         return r.blob();
@@ -489,8 +501,11 @@
       viewSpan.textContent = p.post_text;
       tdContent.appendChild(viewSpan);
 
+      const limit = PLATFORM_LIMITS[p.platform] || null;
+      const exceedsLimit = limit && p.post_text.length > limit;
+
       const editArea = document.createElement("textarea");
-      editArea.className = `post-text-edit${hasPlaceholder ? ' has-warning' : ''}`;
+      editArea.className = `post-text-edit${hasPlaceholder ? ' has-warning' : ''}${exceedsLimit ? ' has-error' : ''}`;
       editArea.dataset.postId = p.id;
       editArea.value = p.post_text;
       
@@ -498,8 +513,12 @@
       cWrap.className = "char-count-wrap";
       const charSpan = document.createElement("span");
       const numSpan = document.createElement("span");
-      numSpan.className = "char-count";
-      numSpan.textContent = p.post_text.length;
+      numSpan.className = `char-count${exceedsLimit ? ' has-warning' : ''}`;
+      if (limit) {
+        numSpan.textContent = `${p.post_text.length} / ${limit}`;
+      } else {
+        numSpan.textContent = p.post_text.length;
+      }
       charSpan.appendChild(numSpan);
       charSpan.appendChild(document.createTextNode(" characters"));
       cWrap.appendChild(charSpan);
@@ -650,11 +669,11 @@
       this.updateSelectedCount();
     },
 
-    renderValidationAlert(pastCount, placeholderCount) {
+    renderValidationAlert(pastCount, placeholderCount, limitExceededCount) {
       const alertContainer = document.getElementById("validation-alert-container");
       if (!alertContainer) return;
 
-      if (pastCount > 0 || placeholderCount > 0) {
+      if (pastCount > 0 || placeholderCount > 0 || limitExceededCount > 0) {
         const alertDiv = document.createElement("div");
         alertDiv.className = "alert alert-warning sm-validation-alert";
 
@@ -669,8 +688,11 @@
         if (placeholderCount > 0) {
           parts.push(`${placeholderCount} post(s) with unresolved placeholders (e.g. {tag})`);
         }
+        if (limitExceededCount > 0) {
+          parts.push(`${limitExceededCount} post(s) exceeding platform character limits`);
+        }
 
-        alertDiv.appendChild(document.createTextNode(parts.join(" and ") + ". Review highlighted rows before exporting."));
+        alertDiv.appendChild(document.createTextNode(parts.join(", ") + ". Review highlighted rows before exporting."));
         alertContainer.textContent = "";
         alertContainer.appendChild(alertDiv);
         alertContainer.style.display = "block";
@@ -819,8 +841,8 @@
     },
 
     triggerValidation() {
-      const { pastCount, placeholderCount } = PostState.validate();
-      UI.renderValidationAlert(pastCount, placeholderCount);
+      const { pastCount, placeholderCount, limitExceededCount } = PostState.validate();
+      UI.renderValidationAlert(pastCount, placeholderCount, limitExceededCount);
     },
 
     saveAndRegenerate(e) {
@@ -902,12 +924,15 @@
         return;
       }
 
-      APIClient.exportCSV(visiblePosts)
+      const presetSelect = document.getElementById("export-preset-select");
+      const exportFormat = presetSelect ? presetSelect.value : "generic";
+
+      APIClient.exportCSV(visiblePosts, exportFormat)
         .then(blob => {
           const url = URL.createObjectURL(blob);
           const a = document.createElement("a");
           a.href = url;
-          a.download = "socialmedia_posts.csv";
+          a.download = `socialmedia_posts_${exportFormat}.csv`;
           document.body.appendChild(a);
           a.click();
           a.remove();
@@ -1046,7 +1071,22 @@
             const row = e.target.closest("tr");
             if (row) {
               const countSpan = row.querySelector(".char-count");
-              if (countSpan) countSpan.textContent = e.target.value.length;
+              if (countSpan) {
+                const post = PostState.get(postId);
+                const limit = PLATFORM_LIMITS[post.platform] || null;
+                if (limit) {
+                  countSpan.textContent = `${e.target.value.length} / ${limit}`;
+                  if (e.target.value.length > limit) {
+                    countSpan.classList.add("has-warning");
+                    e.target.classList.add("has-error");
+                  } else {
+                    countSpan.classList.remove("has-warning");
+                    e.target.classList.remove("has-error");
+                  }
+                } else {
+                  countSpan.textContent = e.target.value.length;
+                }
+              }
             }
           }
         });

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -17,6 +17,14 @@
 
   if (!Config) return;
 
+  // ---- Platform metadata ----
+  const PLATFORM_META = {
+    twitter:  { label: "X / Twitter", iconClass: "fa fa-twitter",   colorClass: "plat-twitter" },
+    mastodon: { label: "Mastodon",    iconClass: "fa fa-globe",      colorClass: "plat-mastodon" },
+    telegram: { label: "Telegram",    iconClass: "fa fa-paper-plane", colorClass: "plat-telegram" },
+    linkedin: { label: "LinkedIn",    iconClass: "fa fa-linkedin",   colorClass: "plat-linkedin" },
+  };
+
   // ---- Helper functions ----
   const Helpers = {
     addDays(dateStr, days) {
@@ -279,15 +287,56 @@
 
       for (let i = 0; i < 5; i++) {
         const tr = document.createElement("tr");
-        tr.className = "skeleton-row";
+        const tdChk = document.createElement("td");
+        const bChk = document.createElement("div");
+        bChk.className = "skeleton-bar";
+        bChk.style.width = "16px";
+        bChk.style.height = "16px";
+        bChk.style.borderRadius = "3px";
+        tdChk.appendChild(bChk);
+        tr.appendChild(tdChk);
 
-        for (let j = 0; j < 6; j++) {
-          const td = document.createElement("td");
-          const bar = document.createElement("div");
-          bar.className = "skeleton-bar";
-          td.appendChild(bar);
-          tr.appendChild(td);
-        }
+        const tdType = document.createElement("td");
+        const bType = document.createElement("div");
+        bType.className = "skeleton-bar";
+        bType.style.width = "60px";
+        tdType.appendChild(bType);
+        tr.appendChild(tdType);
+
+        // Platform column skeleton
+        const tdPlat = document.createElement("td");
+        const bPlat = document.createElement("div");
+        bPlat.className = "skeleton-bar";
+        bPlat.style.width = "80px";
+        tdPlat.appendChild(bPlat);
+        tr.appendChild(tdPlat);
+
+        const tdSched = document.createElement("td");
+        const bSched = document.createElement("div");
+        bSched.className = "skeleton-bar";
+        bSched.style.width = "110px";
+        tdSched.appendChild(bSched);
+        tr.appendChild(tdSched);
+
+        const tdInput = document.createElement("td");
+        const bInput = document.createElement("div");
+        bInput.className = "skeleton-bar";
+        bInput.style.width = "125px";
+        tdInput.appendChild(bInput);
+        tr.appendChild(tdInput);
+
+        const tdText = document.createElement("td");
+        const bText = document.createElement("div");
+        bText.className = "skeleton-bar";
+        tdText.appendChild(bText);
+        tr.appendChild(tdText);
+
+        const tdActions = document.createElement("td");
+        const bActions = document.createElement("div");
+        bActions.className = "skeleton-bar";
+        bActions.style.width = "30px";
+        tdActions.appendChild(bActions);
+        tr.appendChild(tdActions);
 
         tbody.appendChild(tr);
       }
@@ -321,6 +370,29 @@
       typeSpan.textContent = p.type_label;
       tdType.appendChild(typeSpan);
       tr.appendChild(tdType);
+
+      // Platform column
+      const tdPlat = document.createElement("td");
+      if (p.platform) {
+        const meta = PLATFORM_META[p.platform];
+        const platSpan = document.createElement("span");
+        platSpan.className = `platform-badge ${meta ? meta.colorClass : ""}`;
+        if (meta && meta.iconClass) {
+          const icon = document.createElement("i");
+          icon.className = meta.iconClass;
+          platSpan.appendChild(icon);
+          platSpan.appendChild(document.createTextNode(" " + (meta.label || p.platform_label || p.platform)));
+        } else {
+          platSpan.textContent = p.platform_label || p.platform;
+        }
+        tdPlat.appendChild(platSpan);
+      } else {
+        const naSpan = document.createElement("span");
+        naSpan.className = "platform-badge plat-generic";
+        naSpan.textContent = "Generic";
+        tdPlat.appendChild(naSpan);
+      }
+      tr.appendChild(tdPlat);
 
       const tdSched = document.createElement("td");
       tdSched.className = "event-schedule-cell";
@@ -491,7 +563,7 @@
       if (!visible.length) {
         const tr = document.createElement("tr");
         const td = document.createElement("td");
-        td.colSpan = 6;
+        td.colSpan = 7;
 
         const emptyDiv = document.createElement("div");
         emptyDiv.className = "sm-empty";
@@ -723,7 +795,7 @@
             tbody.textContent = "";
             const tr = document.createElement("tr");
             const td = document.createElement("td");
-            td.colSpan = 6;
+            td.colSpan = 7;
 
             const emptyDiv = document.createElement("div");
             emptyDiv.className = "sm-empty";
@@ -1125,6 +1197,20 @@
         input.addEventListener("change", updateFn);
         updateFn();
       }
+    });
+
+    // Platform toggle: show/hide per-platform template fields
+    const platformKeys = ["twitter", "mastodon", "telegram", "linkedin"];
+    platformKeys.forEach(platform => {
+      const checkbox = document.getElementById(`id_socialmedia_${platform}_enabled`);
+      const tplBlock = document.getElementById(`plat-tpls-${platform}`);
+      if (!checkbox || !tplBlock) return;
+
+      const syncVisibility = () => {
+        tplBlock.style.display = checkbox.checked ? "block" : "none";
+      };
+      syncVisibility();
+      checkbox.addEventListener("change", syncVisibility);
     });
   }
   // Run on load

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -98,13 +98,13 @@
         <!-- Skeleton rows -->
         {% for i in "12345" %}
         <tr class="skeleton-row">
-          <td><div class="skeleton-bar" style="width:16px;height:16px;border-radius:3px;"></div></td>
-          <td><div class="skeleton-bar" style="width:60px;"></div></td>
-          <td><div class="skeleton-bar" style="width:80px;"></div></td>
-          <td><div class="skeleton-bar" style="width:110px;"></div></td>
-          <td><div class="skeleton-bar" style="width:125px;"></div></td>
-          <td><div class="skeleton-bar" style="width:100%;"></div></td>
-          <td><div class="skeleton-bar" style="width:30px;"></div></td>
+          <td><div class="skeleton-bar skeleton-col-check"></div></td>
+          <td><div class="skeleton-bar skeleton-col-type"></div></td>
+          <td><div class="skeleton-bar skeleton-col-platform"></div></td>
+          <td><div class="skeleton-bar skeleton-col-date"></div></td>
+          <td><div class="skeleton-bar skeleton-col-postdate"></div></td>
+          <td><div class="skeleton-bar skeleton-col-content"></div></td>
+          <td><div class="skeleton-bar skeleton-col-actions"></div></td>
         </tr>
         {% endfor %}
       </tbody>
@@ -167,17 +167,17 @@
               </div>
             </div>
 
-            <!-- Mastodon -->
-            <div class="platform-block" id="platform-block-mastodon">
+            <!-- LinkedIn -->
+            <div class="platform-block" id="platform-block-linkedin">
               <div class="platform-block-header">
-                {% bootstrap_field form.socialmedia_mastodon_enabled layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_enabled layout="horizontal" %}
               </div>
-              <div class="platform-block-templates" id="plat-tpls-mastodon">
-                {% bootstrap_field form.socialmedia_mastodon_cfp_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_mastodon_speaker_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_mastodon_session_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_mastodon_ticket_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_mastodon_schedule_template layout="horizontal" %}
+              <div class="platform-block-templates" id="plat-tpls-linkedin">
+                {% bootstrap_field form.socialmedia_linkedin_cfp_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_speaker_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_session_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_ticket_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_schedule_template layout="horizontal" %}
               </div>
             </div>
 
@@ -195,17 +195,17 @@
               </div>
             </div>
 
-            <!-- LinkedIn -->
-            <div class="platform-block" id="platform-block-linkedin">
+            <!-- Mastodon -->
+            <div class="platform-block" id="platform-block-mastodon">
               <div class="platform-block-header">
-                {% bootstrap_field form.socialmedia_linkedin_enabled layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_enabled layout="horizontal" %}
               </div>
-              <div class="platform-block-templates" id="plat-tpls-linkedin">
-                {% bootstrap_field form.socialmedia_linkedin_cfp_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_linkedin_speaker_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_linkedin_session_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_linkedin_ticket_template layout="horizontal" %}
-                {% bootstrap_field form.socialmedia_linkedin_schedule_template layout="horizontal" %}
+              <div class="platform-block-templates" id="plat-tpls-mastodon">
+                {% bootstrap_field form.socialmedia_mastodon_cfp_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_speaker_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_session_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_ticket_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_schedule_template layout="horizontal" %}
               </div>
             </div>
           </div>

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -114,10 +114,19 @@
   <!-- Sticky export bar -->
   <div class="export-bar">
     <span class="selected-count" id="export-count">0 {% trans "posts selected" %}</span>
-    <button id="btn-export" class="btn btn-primary btn-export">
-      <i class="fa fa-download"></i> {% trans "Export CSV" %}
-    </button>
+    <div style="display: inline-flex; align-items: center; gap: 8px;">
+      <select id="export-preset-select" class="form-control input-sm" style="width: 150px; display: inline-block;">
+        <option value="generic">{% trans "Generic CSV" %}</option>
+        <option value="postiz">{% trans "Postiz Preset" %}</option>
+        <option value="buffer">{% trans "Buffer Preset" %}</option>
+        <option value="hootsuite">{% trans "Hootsuite Preset" %}</option>
+      </select>
+      <button id="btn-export" class="btn btn-primary btn-export">
+        <i class="fa fa-download"></i> {% trans "Export CSV" %}
+      </button>
+    </div>
   </div>
+
 
   <!-- ================================================================
        Advanced Settings (collapsible)

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -111,15 +111,15 @@
     </table>
   </div>
 
-  <!-- Sticky export bar -->
+  <!-- Export bar (below table, right-aligned) -->
   <div class="export-bar">
     <span class="selected-count" id="export-count">0 {% trans "posts selected" %}</span>
     <div style="display: inline-flex; align-items: center; gap: 8px;">
       <select id="export-preset-select" class="form-control input-sm" style="width: 150px; display: inline-block;">
         <option value="generic">{% trans "Generic CSV" %}</option>
-        <option value="postiz">{% trans "Postiz Preset" %}</option>
-        <option value="buffer">{% trans "Buffer Preset" %}</option>
-        <option value="hootsuite">{% trans "Hootsuite Preset" %}</option>
+        <option value="postiz">{% trans "Postiz CSV" %}</option>
+        <option value="buffer">{% trans "Buffer CSV" %}</option>
+        <option value="hootsuite">{% trans "Hootsuite CSV" %}</option>
       </select>
       <button id="btn-export" class="btn btn-primary btn-export">
         <i class="fa fa-download"></i> {% trans "Export CSV" %}

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -84,6 +84,7 @@
         <tr>
           <th><input type="checkbox" id="chk-all" title="{% trans 'Toggle all' %}"></th>
           <th>{% trans "Type" %}</th>
+          <th>{% trans "Platform" %}</th>
           <th><span title="{% trans 'Official date & time of the session on the event agenda schedule.' %}" class="help-tooltip">{% trans "Schedule Date & Time" %}</span></th>
           <th>
             <span title="{% trans 'The date & time this social media post is scheduled to be published.' %}" class="help-tooltip">{% trans "Post Date & Time" %}</span>
@@ -97,12 +98,13 @@
         <!-- Skeleton rows -->
         {% for i in "12345" %}
         <tr class="skeleton-row">
-          <td><div class="skeleton-bar"></div></td>
-          <td><div class="skeleton-bar"></div></td>
-          <td><div class="skeleton-bar"></div></td>
-          <td><div class="skeleton-bar"></div></td>
-          <td><div class="skeleton-bar"></div></td>
-          <td><div class="skeleton-bar"></div></td>
+          <td><div class="skeleton-bar" style="width:16px;height:16px;border-radius:3px;"></div></td>
+          <td><div class="skeleton-bar" style="width:60px;"></div></td>
+          <td><div class="skeleton-bar" style="width:80px;"></div></td>
+          <td><div class="skeleton-bar" style="width:110px;"></div></td>
+          <td><div class="skeleton-bar" style="width:125px;"></div></td>
+          <td><div class="skeleton-bar" style="width:100%;"></div></td>
+          <td><div class="skeleton-bar" style="width:30px;"></div></td>
         </tr>
         {% endfor %}
       </tbody>
@@ -133,6 +135,72 @@
       <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}
+
+        <!-- Platforms -->
+        <div class="adv-group">
+          <div class="adv-group-title"><i class="fa fa-share-alt"></i> {% trans "Platforms" %}</div>
+          <p class="adv-group-desc">
+            {% trans "Enable the platforms you post to. Each enabled platform generates its own draft row in the preview table with a platform-specific default template. Leave all disabled to generate a single generic draft per content item." %}
+          </p>
+
+          <div class="platform-toggles">
+            <!-- Twitter / X -->
+            <div class="platform-block" id="platform-block-twitter">
+              <div class="platform-block-header">
+                {% bootstrap_field form.socialmedia_twitter_enabled layout="horizontal" %}
+              </div>
+              <div class="platform-block-templates" id="plat-tpls-twitter">
+                {% bootstrap_field form.socialmedia_twitter_cfp_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_twitter_speaker_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_twitter_session_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_twitter_ticket_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_twitter_schedule_template layout="horizontal" %}
+              </div>
+            </div>
+
+            <!-- Mastodon -->
+            <div class="platform-block" id="platform-block-mastodon">
+              <div class="platform-block-header">
+                {% bootstrap_field form.socialmedia_mastodon_enabled layout="horizontal" %}
+              </div>
+              <div class="platform-block-templates" id="plat-tpls-mastodon">
+                {% bootstrap_field form.socialmedia_mastodon_cfp_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_speaker_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_session_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_ticket_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_mastodon_schedule_template layout="horizontal" %}
+              </div>
+            </div>
+
+            <!-- Telegram -->
+            <div class="platform-block" id="platform-block-telegram">
+              <div class="platform-block-header">
+                {% bootstrap_field form.socialmedia_telegram_enabled layout="horizontal" %}
+              </div>
+              <div class="platform-block-templates" id="plat-tpls-telegram">
+                {% bootstrap_field form.socialmedia_telegram_cfp_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_telegram_speaker_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_telegram_session_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_telegram_ticket_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_telegram_schedule_template layout="horizontal" %}
+              </div>
+            </div>
+
+            <!-- LinkedIn -->
+            <div class="platform-block" id="platform-block-linkedin">
+              <div class="platform-block-header">
+                {% bootstrap_field form.socialmedia_linkedin_enabled layout="horizontal" %}
+              </div>
+              <div class="platform-block-templates" id="plat-tpls-linkedin">
+                {% bootstrap_field form.socialmedia_linkedin_cfp_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_speaker_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_session_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_ticket_template layout="horizontal" %}
+                {% bootstrap_field form.socialmedia_linkedin_schedule_template layout="horizontal" %}
+              </div>
+            </div>
+          </div>
+        </div>
 
         <!-- Global -->
         <div class="adv-group">

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -218,11 +218,13 @@ def export_csv(request, organizer, event):
     try:
         body = json.loads(request.body)
         posts = body.get("posts", [])
+        export_format = body.get("format", "generic")
     except (json.JSONDecodeError, KeyError):
         return HttpResponse("Invalid request body.", status=400)
 
-    csv_data = generate_csv_from_posts(posts)
+    csv_data = generate_csv_from_posts(posts, export_format)
     filename = f"{request.event.slug}_socialmedia_posts.csv"
     response = HttpResponse(csv_data, content_type="text/csv; charset=utf-8")
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
     return response
+

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -227,4 +227,3 @@ def export_csv(request, organizer, event):
     response = HttpResponse(csv_data, content_type="text/csv; charset=utf-8")
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
     return response
-

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -340,3 +340,94 @@ def test_post_exclusion_from_preview(
     )
     assert matched_post is not None
     assert matched_post.get("status") == "excluded"
+
+
+# ---------------------------------------------------------------------------
+# Multi-platform tests (Issue #21)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_multi_platform_build_posts(organizer, event):
+    """Enabling 2 platforms should double the number of posts generated, and
+    every post should have a 'platform' field matching one of the enabled ones."""
+    from django_scopes import scope
+
+    from socialmedia.export import build_posts
+
+    with scope(organizer=organizer, event=event):
+        event = event.__class__.objects.get(pk=event.pk)
+        event.settings.set("socialmedia_twitter_enabled", True)
+        event.settings.set("socialmedia_linkedin_enabled", True)
+        # Ensure at least one content type is enabled so posts are generated
+        event.settings.set("socialmedia_schedule_enabled", True)
+        event.settings.flush()
+
+        posts_without_platforms = []
+        # Temporarily collect the count without platforms
+        event.settings.set("socialmedia_twitter_enabled", False)
+        event.settings.set("socialmedia_linkedin_enabled", False)
+        event.settings.flush()
+        posts_without_platforms = build_posts(event)
+
+        event.settings.set("socialmedia_twitter_enabled", True)
+        event.settings.set("socialmedia_linkedin_enabled", True)
+        event.settings.flush()
+        posts_with_platforms = build_posts(event)
+
+    # Posts with 2 platforms should be 2× the generic count (if any generic exist)
+    if posts_without_platforms:
+        assert len(posts_with_platforms) == len(posts_without_platforms) * 2
+
+    # Every post must have a 'platform' key set to one of the enabled platforms
+    for post in posts_with_platforms:
+        assert "platform" in post
+        assert post["platform"] in ("twitter", "linkedin")
+
+
+@pytest.mark.django_db
+def test_platform_uses_correct_template(organizer, event):
+    """A platform-specific saved template should appear in the generated post text."""
+    from django_scopes import scope
+
+    from socialmedia.export import build_posts
+
+    custom_tpl = "CUSTOM_TWITTER_SCHEDULE: {schedule_link}"
+
+    with scope(organizer=organizer, event=event):
+        event = event.__class__.objects.get(pk=event.pk)
+        event.settings.set("socialmedia_twitter_enabled", True)
+        event.settings.set("socialmedia_schedule_enabled", True)
+        event.settings.set("socialmedia_twitter_schedule_template", custom_tpl)
+        event.settings.flush()
+
+        posts = build_posts(event)
+
+    twitter_schedule_posts = [
+        p for p in posts if p["type"] == "schedule" and p.get("platform") == "twitter"
+    ]
+    assert twitter_schedule_posts, "Expected at least one Twitter schedule post"
+    assert all("CUSTOM_TWITTER_SCHEDULE" in p["post_text"] for p in twitter_schedule_posts)
+
+
+@pytest.mark.django_db
+def test_no_platforms_fallback(organizer, event):
+    """When no platforms are enabled, posts should have no platform key (or None)
+    — preserving full backwards compatibility."""
+    from django_scopes import scope
+
+    from socialmedia.export import build_posts
+
+    with scope(organizer=organizer, event=event):
+        event = event.__class__.objects.get(pk=event.pk)
+        for plat in ("twitter", "mastodon", "telegram", "linkedin"):
+            event.settings.set(f"socialmedia_{plat}_enabled", False)
+        event.settings.set("socialmedia_schedule_enabled", True)
+        event.settings.flush()
+
+        posts = build_posts(event)
+
+    for post in posts:
+        assert post.get("platform") is None, (
+            f"Expected no platform on post {post['id']}, got {post['platform']!r}"
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -431,3 +431,57 @@ def test_no_platforms_fallback(organizer, event):
         assert post.get("platform") is None, (
             f"Expected no platform on post {post['id']}, got {post['platform']!r}"
         )
+
+
+@pytest.mark.django_db
+def test_export_csv_presets(logged_in_organizer_client, organizer, event, settings):
+    settings.SITE_URL = "https://testserver"
+    url = reverse(
+        "plugins:socialmedia:export",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    payload_base = {
+        "posts": [
+            {
+                "enabled": True,
+                "post_date": "2026-06-20",
+                "post_time": "12:00",
+                "post_text": "Hello world!",
+                "media_url": "https://testserver/img.png",
+            }
+        ]
+    }
+
+    # Test Postiz preset
+    payload = payload_base.copy()
+    payload["format"] = "postiz"
+    response = logged_in_organizer_client.post(
+        url, data=json.dumps(payload), content_type="application/json"
+    )
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "content,date,time,media" in content
+    assert "Hello world!,2026-06-20,12:00,https://testserver/img.png" in content
+
+    # Test Buffer preset
+    payload = payload_base.copy()
+    payload["format"] = "buffer"
+    response = logged_in_organizer_client.post(
+        url, data=json.dumps(payload), content_type="application/json"
+    )
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "text,scheduled_at,link,image" in content
+    assert "Hello world!,2026-06-20 12:00,,https://testserver/img.png" in content
+
+    # Test Hootsuite preset
+    payload = payload_base.copy()
+    payload["format"] = "hootsuite"
+    response = logged_in_organizer_client.post(
+        url, data=json.dumps(payload), content_type="application/json"
+    )
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "date,time,text,link" in content
+    assert "2026-06-20,12:00,Hello world!,https://testserver/img.png" in content
+

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -407,7 +407,9 @@ def test_platform_uses_correct_template(organizer, event):
         p for p in posts if p["type"] == "schedule" and p.get("platform") == "twitter"
     ]
     assert twitter_schedule_posts, "Expected at least one Twitter schedule post"
-    assert all("CUSTOM_TWITTER_SCHEDULE" in p["post_text"] for p in twitter_schedule_posts)
+    assert all(
+        "CUSTOM_TWITTER_SCHEDULE" in p["post_text"] for p in twitter_schedule_posts
+    )
 
 
 @pytest.mark.django_db
@@ -428,9 +430,9 @@ def test_no_platforms_fallback(organizer, event):
         posts = build_posts(event)
 
     for post in posts:
-        assert post.get("platform") is None, (
-            f"Expected no platform on post {post['id']}, got {post['platform']!r}"
-        )
+        assert (
+            post.get("platform") is None
+        ), f"Expected no platform on post {post['id']}, got {post['platform']!r}"
 
 
 @pytest.mark.django_db
@@ -484,4 +486,3 @@ def test_export_csv_presets(logged_in_organizer_client, organizer, event, settin
     content = response.content.decode("utf-8")
     assert "date,time,text,link" in content
     assert "2026-06-20,12:00,Hello world!,https://testserver/img.png" in content
-


### PR DESCRIPTION
Introduces settings toggles, platform-specific template overrides, fallbacks, real-time character limit validation, and pre-formatted CSV export presets for popular social media schedulers (Postiz, Buffer, Hootsuite).

- closes : #21 , #22 

## Features & Changes

### 1. Multi-Platform Generation Logic (`socialmedia/export.py`)
- Introduced `PLATFORMS` mapping for `twitter`, `mastodon`, `telegram`, and `linkedin`.
- Added platform-specific default templates (`PLATFORM_DEFAULT_TEMPLATES`) tailored to each network (e.g., character limits for X/Twitter and Mastodon, Markdown formatting for Telegram, and a professional tone for LinkedIn).
- Modified `build_posts` to check enabled platforms and generate distinct drafts tagged with a `platform` attribute.
- Built a fallback cascade: Custom Platform Template $\rightarrow$ Platform Default Template $\rightarrow$ Generic Default Template. If no platforms are enabled, it falls back to a single generic post per item for full backwards compatibility.

### 2. Form & Configuration Update (`socialmedia/forms.py`)
- Added boolean fields to toggle each platform (`socialmedia_<platform>_enabled`).
- Added 20 new text-area fields for customizing templates per content type and platform (e.g., `socialmedia_twitter_cfp_template`).

### 3. Dashboard UI & Rendering (`socialmedia/templates/` & `socialmedia/static/`)
- **Table Structure:** Added a **Platform** column in the preview table.
- **Badge Elements:** Rendered visual badges with Font Awesome brand icons (e.g., `<i class="fa fa-twitter"></i> Twitter`, Paper Plane for Telegram, Globe for Mastodon, etc.) and styled colors.
- **Collapsible Settings:** Grouped platform toggles and template customizers inside a styled collapsible "Platforms" drawer in the Advanced Settings panel.
- **Dynamic JavaScript:** Added checkbox listener events to show/hide template configuration groups dynamically on toggle.

### 4. Real-time Character Limit Validation & Export Presets (`socialmedia/static/js/settings.js`, `socialmedia/static/css/settings.css`, `socialmedia/export.py`, `socialmedia/views.py`)
- **Real-time Validation:** Configured platform limits (280 for Twitter, 500 for Mastodon, 4096 for Telegram, 3000 for LinkedIn). The character badge now displays the current/maximum count (e.g. `290 / 280`) and highlights the textarea in red with warning alerts if exceeded.
- **Scheduler Presets Dropdown:** Added a selector in the export bar allowing users to select presets: **Generic CSV**, **Postiz**, **Buffer**, or **Hootsuite**.
- **Preset Formatting:** Mapped column names correctly and merged date/time into `scheduled_at` for Buffer exports.

### 5. Tests (`tests/test_views.py`)
- Added `test_multi_platform_build_posts` to verify that enabling multiple platforms generates distinct draft entries for each platform.
- Added `test_platform_uses_correct_template` to ensure settings-defined platform custom templates are correctly resolved and formatted.
- Added `test_no_platforms_fallback` to ensure backwards compatibility when no platforms are toggled.
- Added `test_export_csv_presets` view test ensuring the headers and combined fields match spec definitions for all presets.

---