### PR TITLE
Implement & Refine Platform and Scheduler Provider Adapters (Telegram, Mastodon, Postiz, Buffer)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ maintainers = [
 ]
 
 dependencies = [
+    "Mastodon.py",
 ]
 
 [project.entry-points."pretix.plugin"]

--- a/socialmedia/forms.py
+++ b/socialmedia/forms.py
@@ -4,6 +4,7 @@ from eventyay.base.forms import SettingsForm
 
 from .export import DEFAULT_TEMPLATES, PLATFORMS
 from .models import SocialMediaAccount
+from .telegram_utils import normalize_telegram_chat_id
 
 MAX_OFFSETS = 10
 MAX_OFFSET_VALUE_CFP = 365
@@ -459,7 +460,11 @@ class TelegramAccountForm(forms.ModelForm):
             "platform_username": _("Channel/Chat ID"),
         }
         help_texts = {
-            "platform_username": _("e.g. @mychannel or -100123456789"),
+            "platform_username": _(
+                "Use @publicusername for public chats/channels or the numeric chat "
+                "ID for private groups, e.g. -100123456789. Invite links cannot be "
+                "used as chat IDs."
+            ),
         }
 
     def __init__(self, *args, **kwargs):
@@ -475,7 +480,18 @@ class TelegramAccountForm(forms.ModelForm):
         if (not token or token == "••••••••") and self.instance and self.instance.pk:
             creds = self.instance.credentials
             return creds.get("bot_token")
-        return token
+        return token.strip() if token else token
+
+    def clean_platform_username(self):
+        value = (self.cleaned_data.get("platform_username") or "").strip()
+        if "t.me/+" in value or "t.me/joinchat/" in value:
+            raise forms.ValidationError(
+                _(
+                    "Telegram invite links cannot be used here. Use a public "
+                    "@username or the numeric chat ID, usually starting with -100."
+                )
+            )
+        return normalize_telegram_chat_id(value)
 
     def save(self, commit=True):
         instance = super().save(commit=False)
@@ -525,7 +541,7 @@ class MastodonAccountForm(forms.ModelForm):
         if (not token or token == "••••••••") and self.instance and self.instance.pk:
             creds = self.instance.credentials
             return creds.get("access_token")
-        return token
+        return token.strip() if token else token
 
     def save(self, commit=True):
         instance = super().save(commit=False)
@@ -576,7 +592,7 @@ class PostizAccountForm(forms.ModelForm):
         if (not key or key == "••••••••") and self.instance and self.instance.pk:
             creds = self.instance.credentials
             return creds.get("api_key")
-        return key
+        return key.strip() if key else key
 
     def save(self, commit=True):
         instance = super().save(commit=False)
@@ -601,10 +617,12 @@ class BufferAccountForm(forms.ModelForm):
         model = SocialMediaAccount
         fields = ["platform_username", "is_active"]
         labels = {
-            "platform_username": _("Configuration Name"),
+            "platform_username": _("Buffer Channel ID"),
         }
         help_texts = {
-            "platform_username": _("e.g. My Organization Buffer Link"),
+            "platform_username": _(
+                "The id of the connected Buffer channel/profile you want to post to."
+            ),
         }
 
     def __init__(self, *args, **kwargs):
@@ -620,7 +638,7 @@ class BufferAccountForm(forms.ModelForm):
         if (not token or token == "••••••••") and self.instance and self.instance.pk:
             creds = self.instance.credentials
             return creds.get("access_token")
-        return token
+        return token.strip() if token else token
 
     def save(self, commit=True):
         instance = super().save(commit=False)

--- a/socialmedia/providers/__init__.py
+++ b/socialmedia/providers/__init__.py
@@ -1,0 +1,9 @@
+from .base import BaseSocialProvider, PublishingError
+from .registry import get_provider, get_provider_class
+
+__all__ = [
+    "BaseSocialProvider",
+    "PublishingError",
+    "get_provider",
+    "get_provider_class",
+]

--- a/socialmedia/providers/base.py
+++ b/socialmedia/providers/base.py
@@ -60,3 +60,8 @@ class BaseSocialProvider:
         and sends them to the scheduling queue in a single sync session.
         """
         return []
+
+    @classmethod
+    def get_setup_instructions(cls) -> list[str]:
+        """Return a list of step-by-step setup instructions for the provider."""
+        return []

--- a/socialmedia/providers/base.py
+++ b/socialmedia/providers/base.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Any, Dict, List, Optional
+from socialmedia.models import SocialMediaAccount
+
+logger = logging.getLogger(__name__)
+
+
+class PublishingError(Exception):
+    """Custom exception raised when post publishing or API sync fails."""
+    pass
+
+
+class BaseSocialProvider:
+    """Abstract base class representing a social media or scheduling provider integration."""
+
+    def __init__(self, account: SocialMediaAccount):
+        self.account = account
+        self.credentials = account.credentials
+
+    def validate_credentials(self) -> bool:
+        """Verify the connection status with the remote platform or aggregator API.
+
+        Returns:
+            bool: True if connection is valid, False otherwise.
+        """
+        raise NotImplementedError("validate_credentials must be implemented by subclasses.")
+
+    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Send text copy and media attachments to the provider API.
+
+        Returns:
+            Dict[str, Any]: A dict containing 'post_id' and 'url' of the published post.
+
+        Raises:
+            PublishingError: If the remote API returns an error or connection fails.
+        """
+        raise NotImplementedError("publish_post must be implemented by subclasses.")
+
+    def sync_campaign(self, posts: List[Any]) -> List[Any]:
+        """(Optional override for schedulers) Batches multiple scheduled posts
+        and sends them to the scheduling queue in a single sync session.
+        """
+        return []

--- a/socialmedia/providers/base.py
+++ b/socialmedia/providers/base.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
+
 from socialmedia.models import SocialMediaAccount
 
 logger = logging.getLogger(__name__)
@@ -7,11 +8,14 @@ logger = logging.getLogger(__name__)
 
 class PublishingError(Exception):
     """Custom exception raised when post publishing or API sync fails."""
+
     pass
 
 
 class BaseSocialProvider:
-    """Abstract base class representing a social media or scheduling provider integration."""
+    """Abstract base class representing a social media or scheduling provider
+    integration.
+    """
 
     def __init__(self, account: SocialMediaAccount):
         self.account = account
@@ -23,9 +27,11 @@ class BaseSocialProvider:
         Returns:
             bool: True if connection is valid, False otherwise.
         """
-        raise NotImplementedError("validate_credentials must be implemented by subclasses.")
+        raise NotImplementedError(
+            "validate_credentials must be implemented by subclasses."
+        )
 
-    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+    def publish_post(self, text: str, media: list[str] | None = None) -> dict[str, Any]:
         """Send text copy and media attachments to the provider API.
 
         Returns:
@@ -36,7 +42,20 @@ class BaseSocialProvider:
         """
         raise NotImplementedError("publish_post must be implemented by subclasses.")
 
-    def sync_campaign(self, posts: List[Any]) -> List[Any]:
+    def send_test_message(self) -> dict[str, Any]:
+        """Send a test message to verify the connection is working.
+
+        Returns:
+            Dict[str, Any]: A dict with 'success' (bool) and 'message' (str).
+
+        Raises:
+            PublishingError: If the test message fails.
+        """
+        raise NotImplementedError(
+            "send_test_message must be implemented by subclasses."
+        )
+
+    def sync_campaign(self, posts: list[Any]) -> list[Any]:
         """(Optional override for schedulers) Batches multiple scheduled posts
         and sends them to the scheduling queue in a single sync session.
         """

--- a/socialmedia/providers/buffer.py
+++ b/socialmedia/providers/buffer.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any
 
@@ -14,82 +15,125 @@ class BufferProvider(BaseSocialProvider):
     def __init__(self, account):
         super().__init__(account)
         self.access_token = self.credentials.get("access_token")
-        self.profile_id = self.account.platform_username
-        self.base_url = "https://api.bufferapp.com/1/"
+        self.channel_id = self.account.platform_username
+        self.base_url = "https://api.buffer.com"
+
+    def _get_headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+
+    def _graphql(self, query: str) -> dict[str, Any]:
+        if not self.access_token:
+            raise PublishingError("Missing Buffer API key.")
+
+        response = requests.post(
+            self.base_url,
+            json={"query": query},
+            headers=self._get_headers(),
+            timeout=15,
+        )
+        if response.status_code != 200:
+            raise PublishingError(f"Buffer API error: {response.text}")
+
+        result = response.json()
+        if result.get("errors"):
+            raise PublishingError(f"Buffer API error: {result['errors']}")
+        return result.get("data", {})
 
     def validate_credentials(self) -> bool:
-        if not self.access_token:
-            return False
         try:
-            url = f"{self.base_url}user.json"
-            response = requests.get(
-                url, params={"access_token": self.access_token}, timeout=10
+            data = self._graphql(
+                """
+                query ValidateBufferAccount {
+                  account {
+                    id
+                    email
+                  }
+                }
+                """
             )
-            return response.status_code == 200
+            return bool(data.get("account"))
         except Exception as e:
             logger.error(f"Buffer credentials validation failed: {e}")
             return False
 
+    def _create_post(self, text: str, *, save_to_draft: bool) -> dict[str, str]:
+        if not self.channel_id:
+            raise PublishingError("Missing Buffer channel ID.")
+
+        text_value = json.dumps(text)
+        channel_id = json.dumps(self.channel_id)
+        draft_value = "true" if save_to_draft else "false"
+        query = f"""
+            mutation CreateEventyayBufferPost {{
+              createPost(input: {{
+                text: {text_value},
+                channelId: {channel_id},
+                schedulingType: automatic,
+                mode: addToQueue,
+                saveToDraft: {draft_value}
+              }}) {{
+                ... on PostActionSuccess {{
+                  post {{
+                    id
+                    text
+                    dueAt
+                  }}
+                }}
+                ... on MutationError {{
+                  message
+                }}
+              }}
+            }}
+            """
+
+        data = self._graphql(query)
+        result = data.get("createPost") or {}
+        if result.get("message"):
+            raise PublishingError(f"Buffer API error: {result['message']}")
+
+        post = result.get("post") or {}
+        post_id = str(post.get("id") or "")
+        return {
+            "post_id": post_id,
+            "url": f"https://publish.buffer.com/content/{post_id}" if post_id else "",
+        }
+
     def send_test_message(self) -> dict[str, Any]:
         if not self.access_token:
-            return {"success": False, "message": "Missing access token."}
+            return {"success": False, "message": "Missing API key."}
         try:
-            url = f"{self.base_url}user.json"
-            response = requests.get(
-                url, params={"access_token": self.access_token}, timeout=10
-            )
-            if response.status_code == 200:
+            if not self.validate_credentials():
                 return {
-                    "success": True,
-                    "message": "Connection successful. Buffer account accessible.",
+                    "success": False,
+                    "message": "Buffer connection failed. API key is not valid.",
                 }
-            return {"success": False, "message": f"Buffer API error: {response.text}"}
+
+            result = self._create_post(
+                "✅ Connection successful from Eventyay!",
+                save_to_draft=True,
+            )
+            details = f" Post ID: {result['post_id']}." if result["post_id"] else ""
+            return {
+                "success": True,
+                "message": f"Test draft created in Buffer.{details}",
+            }
         except requests.RequestException as e:
             return {"success": False, "message": f"Network error: {e}"}
         except Exception as e:
             return {"success": False, "message": str(e)}
 
     def publish_post(self, text: str, media: list[str] | None = None) -> dict[str, Any]:
-        if not self.access_token or not self.profile_id:
-            raise PublishingError("Missing Buffer access token or profile ID.")
+        if not self.access_token or not self.channel_id:
+            raise PublishingError("Missing Buffer API key or channel ID.")
 
-        url = f"{self.base_url}updates/create.json"
-        payload = {
-            "text": text,
-            "profile_ids[]": [self.profile_id],
-        }
-
-        if media and len(media) > 0:
-            media_item = media[0]
-            if media_item.startswith(("http://", "https://")):
-                payload["media[picture]"] = media_item
-                payload["media[thumbnail]"] = media_item
+        if media:
+            logger.warning("Buffer media publishing is not implemented yet.")
 
         try:
-            response = requests.post(
-                url,
-                data=payload,
-                params={"access_token": self.access_token},
-                timeout=15,
-            )
-            if response.status_code != 200:
-                raise PublishingError(f"Buffer API error: {response.text}")
-
-            result = response.json()
-            updates = result.get("updates", [])
-            if not updates:
-                raise PublishingError(
-                    f"Buffer API response did not contain updates: {result}"
-                )
-
-            update = updates[0]
-            post_id = str(update.get("id"))
-            public_url = f"https://publish.buffer.com/profile/{self.profile_id}/queue"
-
-            return {
-                "post_id": post_id,
-                "url": public_url,
-            }
+            return self._create_post(text, save_to_draft=False)
         except requests.RequestException as e:
             raise PublishingError(
                 f"Network error communicating with Buffer API: {e}"

--- a/socialmedia/providers/buffer.py
+++ b/socialmedia/providers/buffer.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Any
+
 import requests
-from typing import Any, Dict, List, Optional
+
 from .base import BaseSocialProvider, PublishingError
 
 logger = logging.getLogger(__name__)
@@ -20,13 +22,34 @@ class BufferProvider(BaseSocialProvider):
             return False
         try:
             url = f"{self.base_url}user.json"
-            response = requests.get(url, params={"access_token": self.access_token}, timeout=10)
+            response = requests.get(
+                url, params={"access_token": self.access_token}, timeout=10
+            )
             return response.status_code == 200
         except Exception as e:
             logger.error(f"Buffer credentials validation failed: {e}")
             return False
 
-    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+    def send_test_message(self) -> dict[str, Any]:
+        if not self.access_token:
+            return {"success": False, "message": "Missing access token."}
+        try:
+            url = f"{self.base_url}user.json"
+            response = requests.get(
+                url, params={"access_token": self.access_token}, timeout=10
+            )
+            if response.status_code == 200:
+                return {
+                    "success": True,
+                    "message": "Connection successful. Buffer account accessible.",
+                }
+            return {"success": False, "message": f"Buffer API error: {response.text}"}
+        except requests.RequestException as e:
+            return {"success": False, "message": f"Network error: {e}"}
+        except Exception as e:
+            return {"success": False, "message": str(e)}
+
+    def publish_post(self, text: str, media: list[str] | None = None) -> dict[str, Any]:
         if not self.access_token or not self.profile_id:
             raise PublishingError("Missing Buffer access token or profile ID.")
 
@@ -47,7 +70,7 @@ class BufferProvider(BaseSocialProvider):
                 url,
                 data=payload,
                 params={"access_token": self.access_token},
-                timeout=15
+                timeout=15,
             )
             if response.status_code != 200:
                 raise PublishingError(f"Buffer API error: {response.text}")
@@ -55,7 +78,9 @@ class BufferProvider(BaseSocialProvider):
             result = response.json()
             updates = result.get("updates", [])
             if not updates:
-                raise PublishingError(f"Buffer API response did not contain updates: {result}")
+                raise PublishingError(
+                    f"Buffer API response did not contain updates: {result}"
+                )
 
             update = updates[0]
             post_id = str(update.get("id"))
@@ -66,6 +91,8 @@ class BufferProvider(BaseSocialProvider):
                 "url": public_url,
             }
         except requests.RequestException as e:
-            raise PublishingError(f"Network error communicating with Buffer API: {e}")
+            raise PublishingError(
+                f"Network error communicating with Buffer API: {e}"
+            ) from e
         except Exception as e:
-            raise PublishingError(f"Error publishing to Buffer: {e}")
+            raise PublishingError(f"Error publishing to Buffer: {e}") from e

--- a/socialmedia/providers/buffer.py
+++ b/socialmedia/providers/buffer.py
@@ -140,3 +140,11 @@ class BufferProvider(BaseSocialProvider):
             ) from e
         except Exception as e:
             raise PublishingError(f"Error publishing to Buffer: {e}") from e
+
+    @classmethod
+    def get_setup_instructions(cls) -> list[str]:
+        return [
+            "Access the Buffer Developer Portal (https://publish.buffer.com/developers).",
+            "Register a new developer application to generate an Access Token.",
+            "Copy the Access Token and input it above.",
+        ]

--- a/socialmedia/providers/buffer.py
+++ b/socialmedia/providers/buffer.py
@@ -1,0 +1,71 @@
+import logging
+import requests
+from typing import Any, Dict, List, Optional
+from .base import BaseSocialProvider, PublishingError
+
+logger = logging.getLogger(__name__)
+
+
+class BufferProvider(BaseSocialProvider):
+    """Buffer API integration adapter."""
+
+    def __init__(self, account):
+        super().__init__(account)
+        self.access_token = self.credentials.get("access_token")
+        self.profile_id = self.account.platform_username
+        self.base_url = "https://api.bufferapp.com/1/"
+
+    def validate_credentials(self) -> bool:
+        if not self.access_token:
+            return False
+        try:
+            url = f"{self.base_url}user.json"
+            response = requests.get(url, params={"access_token": self.access_token}, timeout=10)
+            return response.status_code == 200
+        except Exception as e:
+            logger.error(f"Buffer credentials validation failed: {e}")
+            return False
+
+    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+        if not self.access_token or not self.profile_id:
+            raise PublishingError("Missing Buffer access token or profile ID.")
+
+        url = f"{self.base_url}updates/create.json"
+        payload = {
+            "text": text,
+            "profile_ids[]": [self.profile_id],
+        }
+
+        if media and len(media) > 0:
+            media_item = media[0]
+            if media_item.startswith(("http://", "https://")):
+                payload["media[picture]"] = media_item
+                payload["media[thumbnail]"] = media_item
+
+        try:
+            response = requests.post(
+                url,
+                data=payload,
+                params={"access_token": self.access_token},
+                timeout=15
+            )
+            if response.status_code != 200:
+                raise PublishingError(f"Buffer API error: {response.text}")
+
+            result = response.json()
+            updates = result.get("updates", [])
+            if not updates:
+                raise PublishingError(f"Buffer API response did not contain updates: {result}")
+
+            update = updates[0]
+            post_id = str(update.get("id"))
+            public_url = f"https://publish.buffer.com/profile/{self.profile_id}/queue"
+
+            return {
+                "post_id": post_id,
+                "url": public_url,
+            }
+        except requests.RequestException as e:
+            raise PublishingError(f"Network error communicating with Buffer API: {e}")
+        except Exception as e:
+            raise PublishingError(f"Error publishing to Buffer: {e}")

--- a/socialmedia/providers/mastodon.py
+++ b/socialmedia/providers/mastodon.py
@@ -93,3 +93,15 @@ class MastodonProvider(BaseSocialProvider):
 
         except Exception as e:
             raise PublishingError(f"Error publishing status to Mastodon: {e}") from e
+
+    @classmethod
+    def get_setup_instructions(cls) -> list[str]:
+        return [
+            "Log in to your Mastodon instance page.",
+            "Navigate to Preferences -> Development -> New Application.",
+            (
+                "Give the application a name and ensure it has "
+                "'write:statuses' or 'write' scope permissions authorized."
+            ),
+            "Click Save, click on your new application, and copy the Access Token.",
+        ]

--- a/socialmedia/providers/mastodon.py
+++ b/socialmedia/providers/mastodon.py
@@ -1,0 +1,79 @@
+import logging
+from typing import Any, Dict, List, Optional
+from mastodon import Mastodon
+from .base import BaseSocialProvider, PublishingError
+
+logger = logging.getLogger(__name__)
+
+
+class MastodonProvider(BaseSocialProvider):
+    """Mastodon API integration adapter using Mastodon.py."""
+
+    def __init__(self, account):
+        super().__init__(account)
+        self.api_base_url = self.credentials.get("api_base_url")
+        self.access_token = self.credentials.get("access_token")
+        self._client = None
+
+    @property
+    def client(self) -> Mastodon:
+        if not self._client:
+            if not self.api_base_url or not self.access_token:
+                raise PublishingError("Missing Mastodon base URL or access token.")
+            try:
+                self._client = Mastodon(
+                    access_token=self.access_token,
+                    api_base_url=self.api_base_url,
+                )
+            except Exception as e:
+                raise PublishingError(f"Failed to initialize Mastodon client: {e}")
+        return self._client
+
+    def validate_credentials(self) -> bool:
+        try:
+            self.client.account_verify_credentials()
+            return True
+        except Exception as e:
+            logger.error(f"Mastodon credentials validation failed: {e}")
+            return False
+
+    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+        try:
+            media_ids = []
+            if media:
+                for file_path in media:
+                    import requests
+                    import tempfile
+                    import os
+
+                    if file_path.startswith(("http://", "https://")):
+                        r = requests.get(file_path, timeout=20)
+                        r.raise_for_status()
+                        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                            tmp.write(r.content)
+                            tmp_path = tmp.name
+                        try:
+                            res = self.client.media_post(tmp_path)
+                            media_ids.append(res["id"])
+                        finally:
+                            if os.path.exists(tmp_path):
+                                os.remove(tmp_path)
+                    else:
+                        res = self.client.media_post(file_path)
+                        media_ids.append(res["id"])
+
+            status = self.client.status_post(
+                status=text,
+                media_ids=media_ids if media_ids else None,
+            )
+
+            post_id = str(status.get("id"))
+            url = status.get("url") or f"{self.api_base_url}/@{self.account.platform_username}/{post_id}"
+
+            return {
+                "post_id": post_id,
+                "url": url,
+            }
+
+        except Exception as e:
+            raise PublishingError(f"Error publishing status to Mastodon: {e}")

--- a/socialmedia/providers/mastodon.py
+++ b/socialmedia/providers/mastodon.py
@@ -1,6 +1,8 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
+
 from mastodon import Mastodon
+
 from .base import BaseSocialProvider, PublishingError
 
 logger = logging.getLogger(__name__)
@@ -26,7 +28,9 @@ class MastodonProvider(BaseSocialProvider):
                     api_base_url=self.api_base_url,
                 )
             except Exception as e:
-                raise PublishingError(f"Failed to initialize Mastodon client: {e}")
+                raise PublishingError(
+                    f"Failed to initialize Mastodon client: {e}"
+                ) from e
         return self._client
 
     def validate_credentials(self) -> bool:
@@ -37,14 +41,23 @@ class MastodonProvider(BaseSocialProvider):
             logger.error(f"Mastodon credentials validation failed: {e}")
             return False
 
-    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+    def send_test_message(self) -> dict[str, Any]:
+        try:
+            self.client.account_verify_credentials()
+            self.client.status_post(status="✅ Connection successful from Eventyay!")
+            return {"success": True, "message": "Test post published successfully."}
+        except Exception as e:
+            return {"success": False, "message": f"Mastodon API error: {e}"}
+
+    def publish_post(self, text: str, media: list[str] | None = None) -> dict[str, Any]:
         try:
             media_ids = []
             if media:
                 for file_path in media:
-                    import requests
-                    import tempfile
                     import os
+                    import tempfile
+
+                    import requests
 
                     if file_path.startswith(("http://", "https://")):
                         r = requests.get(file_path, timeout=20)
@@ -68,7 +81,10 @@ class MastodonProvider(BaseSocialProvider):
             )
 
             post_id = str(status.get("id"))
-            url = status.get("url") or f"{self.api_base_url}/@{self.account.platform_username}/{post_id}"
+            url = (
+                status.get("url")
+                or f"{self.api_base_url}/@{self.account.platform_username}/{post_id}"
+            )
 
             return {
                 "post_id": post_id,
@@ -76,4 +92,4 @@ class MastodonProvider(BaseSocialProvider):
             }
 
         except Exception as e:
-            raise PublishingError(f"Error publishing status to Mastodon: {e}")
+            raise PublishingError(f"Error publishing status to Mastodon: {e}") from e

--- a/socialmedia/providers/postiz.py
+++ b/socialmedia/providers/postiz.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Any
+
 import requests
-from typing import Any, Dict, List, Optional
+
 from .base import BaseSocialProvider, PublishingError
 
 logger = logging.getLogger(__name__)
@@ -31,7 +33,24 @@ class PostizProvider(BaseSocialProvider):
             logger.error(f"Postiz credentials validation failed: {e}")
             return False
 
-    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+    def send_test_message(self) -> dict[str, Any]:
+        if not self.api_url or not self.api_key:
+            return {"success": False, "message": "Missing API URL or API key."}
+        try:
+            url = f"{self.api_url.rstrip('/')}/v1/workspaces"
+            response = requests.get(url, headers=self._get_headers(), timeout=10)
+            if response.status_code == 200:
+                return {
+                    "success": True,
+                    "message": "Connection successful. Workspaces accessible.",
+                }
+            return {"success": False, "message": f"Postiz API error: {response.text}"}
+        except requests.RequestException as e:
+            return {"success": False, "message": f"Network error: {e}"}
+        except Exception as e:
+            return {"success": False, "message": str(e)}
+
+    def publish_post(self, text: str, media: list[str] | None = None) -> dict[str, Any]:
         if not self.api_url or not self.api_key:
             raise PublishingError("Missing Postiz API URL or API key.")
 
@@ -43,19 +62,25 @@ class PostizProvider(BaseSocialProvider):
             payload["media"] = media
 
         try:
-            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=15)
+            response = requests.post(
+                url, json=payload, headers=self._get_headers(), timeout=15
+            )
             if response.status_code not in [200, 201]:
                 raise PublishingError(f"Postiz API error: {response.text}")
 
             result = response.json()
             post_id = str(result.get("id"))
-            public_url = result.get("url") or f"{self.api_url.rstrip('/')}/posts/{post_id}"
+            public_url = (
+                result.get("url") or f"{self.api_url.rstrip('/')}/posts/{post_id}"
+            )
 
             return {
                 "post_id": post_id,
                 "url": public_url,
             }
         except requests.RequestException as e:
-            raise PublishingError(f"Network error communicating with Postiz API: {e}")
+            raise PublishingError(
+                f"Network error communicating with Postiz API: {e}"
+            ) from e
         except Exception as e:
-            raise PublishingError(f"Error publishing to Postiz: {e}")
+            raise PublishingError(f"Error publishing to Postiz: {e}") from e

--- a/socialmedia/providers/postiz.py
+++ b/socialmedia/providers/postiz.py
@@ -37,16 +37,36 @@ class PostizProvider(BaseSocialProvider):
         if not self.api_url or not self.api_key:
             return {"success": False, "message": "Missing API URL or API key."}
         try:
-            url = f"{self.api_url.rstrip('/')}/v1/workspaces"
-            response = requests.get(url, headers=self._get_headers(), timeout=10)
-            if response.status_code == 200:
+            if not self.validate_credentials():
                 return {
-                    "success": True,
-                    "message": "Connection successful. Workspaces accessible.",
+                    "success": False,
+                    "message": (
+                        "Postiz connection failed. Workspaces are not accessible."
+                    ),
                 }
-            return {"success": False, "message": f"Postiz API error: {response.text}"}
+
+            result = self.publish_post("✅ Connection successful from Eventyay!")
+            post_id = result.get("post_id")
+            url = result.get("url")
+            details = f" Post ID: {post_id}." if post_id else ""
+            if url:
+                details += f" URL: {url}."
+            if not details:
+                details = " Postiz accepted the request; check your Postiz posts."
+            return {
+                "success": True,
+                "message": f"Test post created in Postiz.{details}",
+            }
         except requests.RequestException as e:
             return {"success": False, "message": f"Network error: {e}"}
+        except PublishingError as e:
+            return {
+                "success": False,
+                "message": (
+                    "Postiz connection works, but creating a visible test post failed: "
+                    f"{e}"
+                ),
+            }
         except Exception as e:
             return {"success": False, "message": str(e)}
 
@@ -65,18 +85,25 @@ class PostizProvider(BaseSocialProvider):
             response = requests.post(
                 url, json=payload, headers=self._get_headers(), timeout=15
             )
-            if response.status_code not in [200, 201]:
+            if response.status_code not in [200, 201, 204]:
                 raise PublishingError(f"Postiz API error: {response.text}")
 
-            result = response.json()
-            post_id = str(result.get("id"))
-            public_url = (
-                result.get("url") or f"{self.api_url.rstrip('/')}/posts/{post_id}"
-            )
+            result = {}
+            if response.text and response.text.strip():
+                try:
+                    result = response.json()
+                except ValueError:
+                    logger.warning(
+                        "Postiz returned a successful non-JSON response: %s",
+                        response.text,
+                    )
+
+            post_id = result.get("id") or result.get("postId")
+            public_url = result.get("url")
 
             return {
-                "post_id": post_id,
-                "url": public_url,
+                "post_id": str(post_id) if post_id else "",
+                "url": public_url or "",
             }
         except requests.RequestException as e:
             raise PublishingError(

--- a/socialmedia/providers/postiz.py
+++ b/socialmedia/providers/postiz.py
@@ -111,3 +111,12 @@ class PostizProvider(BaseSocialProvider):
             ) from e
         except Exception as e:
             raise PublishingError(f"Error publishing to Postiz: {e}") from e
+
+    @classmethod
+    def get_setup_instructions(cls) -> list[str]:
+        return [
+            "Log in to your Postiz dashboard instance.",
+            "Navigate to Settings -> API Keys (or Developer Settings).",
+            "Generate a new API Key and copy the value.",
+            "Enter your Postiz API instance URL and key to establish connection.",
+        ]

--- a/socialmedia/providers/postiz.py
+++ b/socialmedia/providers/postiz.py
@@ -1,0 +1,61 @@
+import logging
+import requests
+from typing import Any, Dict, List, Optional
+from .base import BaseSocialProvider, PublishingError
+
+logger = logging.getLogger(__name__)
+
+
+class PostizProvider(BaseSocialProvider):
+    """Postiz API integration adapter."""
+
+    def __init__(self, account):
+        super().__init__(account)
+        self.api_url = self.credentials.get("api_url")
+        self.api_key = self.credentials.get("api_key")
+
+    def _get_headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def validate_credentials(self) -> bool:
+        if not self.api_url or not self.api_key:
+            return False
+        try:
+            url = f"{self.api_url.rstrip('/')}/v1/workspaces"
+            response = requests.get(url, headers=self._get_headers(), timeout=10)
+            return response.status_code == 200
+        except Exception as e:
+            logger.error(f"Postiz credentials validation failed: {e}")
+            return False
+
+    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+        if not self.api_url or not self.api_key:
+            raise PublishingError("Missing Postiz API URL or API key.")
+
+        url = f"{self.api_url.rstrip('/')}/v1/posts"
+        payload = {
+            "content": text,
+        }
+        if media:
+            payload["media"] = media
+
+        try:
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=15)
+            if response.status_code not in [200, 201]:
+                raise PublishingError(f"Postiz API error: {response.text}")
+
+            result = response.json()
+            post_id = str(result.get("id"))
+            public_url = result.get("url") or f"{self.api_url.rstrip('/')}/posts/{post_id}"
+
+            return {
+                "post_id": post_id,
+                "url": public_url,
+            }
+        except requests.RequestException as e:
+            raise PublishingError(f"Network error communicating with Postiz API: {e}")
+        except Exception as e:
+            raise PublishingError(f"Error publishing to Postiz: {e}")

--- a/socialmedia/providers/registry.py
+++ b/socialmedia/providers/registry.py
@@ -1,11 +1,10 @@
-from typing import Dict, Type
 from .base import BaseSocialProvider
-from .telegram import TelegramProvider
+from .buffer import BufferProvider
 from .mastodon import MastodonProvider
 from .postiz import PostizProvider
-from .buffer import BufferProvider
+from .telegram import TelegramProvider
 
-_registry: Dict[str, Type[BaseSocialProvider]] = {
+_registry: dict[str, type[BaseSocialProvider]] = {
     "telegram": TelegramProvider,
     "mastodon": MastodonProvider,
     "postiz": PostizProvider,
@@ -13,7 +12,7 @@ _registry: Dict[str, Type[BaseSocialProvider]] = {
 }
 
 
-def get_provider_class(provider_name: str) -> Type[BaseSocialProvider]:
+def get_provider_class(provider_name: str) -> type[BaseSocialProvider]:
     """Retrieve the provider adapter class for the given provider name.
 
     Args:
@@ -26,7 +25,9 @@ def get_provider_class(provider_name: str) -> Type[BaseSocialProvider]:
         ValueError: If the provider is not supported or registered.
     """
     if provider_name not in _registry:
-        raise ValueError(f"Unsupported or unregistered social media provider: {provider_name}")
+        raise ValueError(
+            f"Unsupported or unregistered social media provider: {provider_name}"
+        )
     return _registry[provider_name]
 
 

--- a/socialmedia/providers/registry.py
+++ b/socialmedia/providers/registry.py
@@ -1,0 +1,43 @@
+from typing import Dict, Type
+from .base import BaseSocialProvider
+from .telegram import TelegramProvider
+from .mastodon import MastodonProvider
+from .postiz import PostizProvider
+from .buffer import BufferProvider
+
+_registry: Dict[str, Type[BaseSocialProvider]] = {
+    "telegram": TelegramProvider,
+    "mastodon": MastodonProvider,
+    "postiz": PostizProvider,
+    "buffer": BufferProvider,
+}
+
+
+def get_provider_class(provider_name: str) -> Type[BaseSocialProvider]:
+    """Retrieve the provider adapter class for the given provider name.
+
+    Args:
+        provider_name (str): The name of the provider (e.g. 'telegram', 'mastodon').
+
+    Returns:
+        Type[BaseSocialProvider]: The provider adapter class.
+
+    Raises:
+        ValueError: If the provider is not supported or registered.
+    """
+    if provider_name not in _registry:
+        raise ValueError(f"Unsupported or unregistered social media provider: {provider_name}")
+    return _registry[provider_name]
+
+
+def get_provider(account) -> BaseSocialProvider:
+    """Instantiate and return the provider adapter for the given SocialMediaAccount.
+
+    Args:
+        account (SocialMediaAccount): The account instance with provider credentials.
+
+    Returns:
+        BaseSocialProvider: An instance of the provider adapter.
+    """
+    provider_cls = get_provider_class(account.provider)
+    return provider_cls(account)

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Any
+
 import requests
-from typing import Any, Dict, List, Optional
+
 from .base import BaseSocialProvider, PublishingError
 
 logger = logging.getLogger(__name__)
@@ -28,7 +30,31 @@ class TelegramProvider(BaseSocialProvider):
             logger.error(f"Telegram credentials validation failed: {e}")
             return False
 
-    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+    def send_test_message(self) -> dict[str, Any]:
+        if not self.token or not self.chat_id:
+            return {"success": False, "message": "Missing bot token or chat ID."}
+        try:
+            url = f"{self.base_url}sendMessage"
+            payload = {
+                "chat_id": self.chat_id,
+                "text": "✅ Connection successful from Eventyay!",
+                "parse_mode": "Markdown",
+            }
+            response = requests.post(url, data=payload, timeout=15)
+            if response.status_code == 200:
+                result = response.json()
+                if result.get("ok"):
+                    return {
+                        "success": True,
+                        "message": "Test message sent successfully.",
+                    }
+            return {"success": False, "message": f"Telegram API error: {response.text}"}
+        except requests.RequestException as e:
+            return {"success": False, "message": f"Network error: {e}"}
+        except Exception as e:
+            return {"success": False, "message": str(e)}
+
+    def publish_post(self, text: str, media: list[str] | None = None) -> dict[str, Any]:
         if not self.token or not self.chat_id:
             raise PublishingError("Missing Telegram bot token or chat ID.")
 
@@ -43,27 +69,35 @@ class TelegramProvider(BaseSocialProvider):
 
                 if is_url:
                     url = f"{self.base_url}sendPhoto"
-                    payload.update({
-                        "photo": media_item,
-                        "caption": text,
-                        "parse_mode": "Markdown",
-                    })
+                    payload.update(
+                        {
+                            "photo": media_item,
+                            "caption": text,
+                            "parse_mode": "Markdown",
+                        }
+                    )
                     response = requests.post(url, data=payload, timeout=15)
                 else:
                     url = f"{self.base_url}sendPhoto"
-                    payload.update({
-                        "caption": text,
-                        "parse_mode": "Markdown",
-                    })
+                    payload.update(
+                        {
+                            "caption": text,
+                            "parse_mode": "Markdown",
+                        }
+                    )
                     with open(media_item, "rb") as f:
                         files = {"photo": f}
-                        response = requests.post(url, data=payload, files=files, timeout=20)
+                        response = requests.post(
+                            url, data=payload, files=files, timeout=20
+                        )
             else:
                 url = f"{self.base_url}sendMessage"
-                payload.update({
-                    "text": text,
-                    "parse_mode": "Markdown",
-                })
+                payload.update(
+                    {
+                        "text": text,
+                        "parse_mode": "Markdown",
+                    }
+                )
                 response = requests.post(url, data=payload, timeout=15)
 
             if response.status_code != 200:
@@ -87,6 +121,8 @@ class TelegramProvider(BaseSocialProvider):
             }
 
         except requests.RequestException as e:
-            raise PublishingError(f"Network error communicating with Telegram Bot API: {e}")
+            raise PublishingError(
+                f"Network error communicating with Telegram Bot API: {e}"
+            ) from e
         except Exception as e:
-            raise PublishingError(f"Error publishing to Telegram: {e}")
+            raise PublishingError(f"Error publishing to Telegram: {e}") from e

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -177,7 +177,12 @@ class TelegramProvider(BaseSocialProvider):
                 username = self.chat_id.lstrip("@")
                 url_val = f"https://t.me/{username}/{post_id}"
             else:
-                url_val = f"https://t.me/c/{self.chat_id}/{post_id}"
+                clean_id = self.chat_id
+                if clean_id.startswith("-100"):
+                    clean_id = clean_id[4:]
+                elif clean_id.startswith("-"):
+                    clean_id = clean_id[1:]
+                url_val = f"https://t.me/c/{clean_id}/{post_id}"
 
             return {
                 "post_id": post_id,

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -190,3 +190,16 @@ class TelegramProvider(BaseSocialProvider):
             ) from e
         except Exception as e:
             raise PublishingError(f"Error publishing to Telegram: {e}") from e
+
+    @classmethod
+    def get_setup_instructions(cls) -> list[str]:
+        return [
+            "Message @BotFather on Telegram and send /newbot to create your bot.",
+            "Copy the Bot API Token provided by BotFather.",
+            "Add the bot as an administrator (or member) to your target group/channel.",
+            (
+                "Obtain the numeric Channel/Chat ID (prefixed with -100 for "
+                "supergroups, e.g. -1004301847700) or public @username, then "
+                "input it above."
+            ),
+        ]

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import requests
 
+from socialmedia.telegram_utils import normalize_telegram_chat_id
+
 from .base import BaseSocialProvider, PublishingError
 
 logger = logging.getLogger(__name__)
@@ -14,7 +16,7 @@ class TelegramProvider(BaseSocialProvider):
     def __init__(self, account):
         super().__init__(account)
         self.token = self.credentials.get("bot_token")
-        self.chat_id = self.account.platform_username
+        self.chat_id = normalize_telegram_chat_id(self.account.platform_username)
         self.base_url = f"https://api.telegram.org/bot{self.token}/"
 
     def validate_credentials(self) -> bool:
@@ -22,10 +24,18 @@ class TelegramProvider(BaseSocialProvider):
             return False
         try:
             response = requests.get(f"{self.base_url}getMe", timeout=10)
-            if response.status_code == 200:
-                data = response.json()
-                return data.get("ok", False)
-            return False
+            if response.status_code != 200 or not response.json().get("ok", False):
+                return False
+
+            if self.chat_id:
+                response = requests.get(
+                    f"{self.base_url}getChat",
+                    params={"chat_id": self._resolve_chat_id()},
+                    timeout=10,
+                )
+                return response.status_code == 200 and response.json().get("ok", False)
+
+            return True
         except Exception as e:
             logger.error(f"Telegram credentials validation failed: {e}")
             return False
@@ -34,11 +44,12 @@ class TelegramProvider(BaseSocialProvider):
         if not self.token or not self.chat_id:
             return {"success": False, "message": "Missing bot token or chat ID."}
         try:
+            bot_info = self._get_bot_info()
+
             url = f"{self.base_url}sendMessage"
             payload = {
-                "chat_id": self.chat_id,
+                "chat_id": self._resolve_chat_id(),
                 "text": "✅ Connection successful from Eventyay!",
-                "parse_mode": "Markdown",
             }
             response = requests.post(url, data=payload, timeout=15)
             if response.status_code == 200:
@@ -46,20 +57,73 @@ class TelegramProvider(BaseSocialProvider):
                 if result.get("ok"):
                     return {
                         "success": True,
-                        "message": "Test message sent successfully.",
+                        "message": (
+                            f"Test message sent successfully using bot {bot_info}."
+                        ),
                     }
-            return {"success": False, "message": f"Telegram API error: {response.text}"}
+
+            try:
+                err_data = response.json()
+                desc = err_data.get("description", response.text)
+            except Exception:
+                desc = response.text
+
+            return {
+                "success": False,
+                "message": (
+                    f"Telegram API error: {desc} (Using bot: {bot_info}). "
+                    f"{self._error_hint(desc)}"
+                ),
+            }
         except requests.RequestException as e:
             return {"success": False, "message": f"Network error: {e}"}
         except Exception as e:
             return {"success": False, "message": str(e)}
+
+    def _resolve_chat_id(self):
+        """Return chat_id as int if numeric, otherwise keep as string.
+
+        (e.g. @channel)
+        """
+        raw = self.chat_id
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            return raw
+
+    def _get_bot_info(self) -> str:
+        try:
+            me_res = requests.get(f"{self.base_url}getMe", timeout=10)
+            if me_res.status_code == 200:
+                me_data = me_res.json()
+                if me_data.get("ok"):
+                    result = me_data.get("result", {})
+                    username = result.get("username") or "unknown"
+                    first_name = result.get("first_name") or "Telegram bot"
+                    return f"@{username} ({first_name})"
+        except Exception:
+            pass
+        return "Unknown Bot"
+
+    def _error_hint(self, description: str) -> str:
+        desc = description.lower()
+        if "chat not found" in desc:
+            return (
+                "For private groups, use the numeric chat ID, usually starting with "
+                "-100. Public @usernames work only for public groups/channels."
+            )
+        if "not enough rights" in desc or "not enough permission" in desc:
+            return "Please confirm the bot is an admin and can send messages."
+        if "bot was kicked" in desc or "bot is not a member" in desc:
+            return "Please add this exact bot back to the group or channel."
+        return "Please check the bot token, target chat ID, and bot permissions."
 
     def publish_post(self, text: str, media: list[str] | None = None) -> dict[str, Any]:
         if not self.token or not self.chat_id:
             raise PublishingError("Missing Telegram bot token or chat ID.")
 
         payload = {
-            "chat_id": self.chat_id,
+            "chat_id": self._resolve_chat_id(),
         }
 
         try:

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -1,0 +1,92 @@
+import logging
+import requests
+from typing import Any, Dict, List, Optional
+from .base import BaseSocialProvider, PublishingError
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramProvider(BaseSocialProvider):
+    """Telegram Bot API integration adapter."""
+
+    def __init__(self, account):
+        super().__init__(account)
+        self.token = self.credentials.get("bot_token")
+        self.chat_id = self.account.platform_username
+        self.base_url = f"https://api.telegram.org/bot{self.token}/"
+
+    def validate_credentials(self) -> bool:
+        if not self.token:
+            return False
+        try:
+            response = requests.get(f"{self.base_url}getMe", timeout=10)
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("ok", False)
+            return False
+        except Exception as e:
+            logger.error(f"Telegram credentials validation failed: {e}")
+            return False
+
+    def publish_post(self, text: str, media: Optional[List[str]] = None) -> Dict[str, Any]:
+        if not self.token or not self.chat_id:
+            raise PublishingError("Missing Telegram bot token or chat ID.")
+
+        payload = {
+            "chat_id": self.chat_id,
+        }
+
+        try:
+            if media and len(media) > 0:
+                media_item = media[0]
+                is_url = media_item.startswith(("http://", "https://"))
+
+                if is_url:
+                    url = f"{self.base_url}sendPhoto"
+                    payload.update({
+                        "photo": media_item,
+                        "caption": text,
+                        "parse_mode": "Markdown",
+                    })
+                    response = requests.post(url, data=payload, timeout=15)
+                else:
+                    url = f"{self.base_url}sendPhoto"
+                    payload.update({
+                        "caption": text,
+                        "parse_mode": "Markdown",
+                    })
+                    with open(media_item, "rb") as f:
+                        files = {"photo": f}
+                        response = requests.post(url, data=payload, files=files, timeout=20)
+            else:
+                url = f"{self.base_url}sendMessage"
+                payload.update({
+                    "text": text,
+                    "parse_mode": "Markdown",
+                })
+                response = requests.post(url, data=payload, timeout=15)
+
+            if response.status_code != 200:
+                raise PublishingError(f"Telegram API error: {response.text}")
+
+            result = response.json()
+            if not result.get("ok"):
+                raise PublishingError(f"Telegram API response error: {result}")
+
+            message = result.get("result", {})
+            post_id = str(message.get("message_id"))
+            if self.chat_id.startswith("@"):
+                username = self.chat_id.lstrip("@")
+                url_val = f"https://t.me/{username}/{post_id}"
+            else:
+                url_val = f"https://t.me/c/{self.chat_id}/{post_id}"
+
+            return {
+                "post_id": post_id,
+                "url": url_val,
+            }
+
+        except requests.RequestException as e:
+            raise PublishingError(f"Network error communicating with Telegram Bot API: {e}")
+        except Exception as e:
+            raise PublishingError(f"Error publishing to Telegram: {e}")

--- a/socialmedia/telegram_utils.py
+++ b/socialmedia/telegram_utils.py
@@ -1,0 +1,22 @@
+from urllib.parse import urlparse
+
+
+def normalize_telegram_chat_id(value: str) -> str:
+    value = (value or "").strip()
+    parse_value = value
+    if value.startswith(("t.me/", "telegram.me/")):
+        parse_value = f"https://{value}"
+
+    parsed = urlparse(parse_value)
+    if parsed.netloc in {"t.me", "telegram.me"}:
+        path = parsed.path.strip("/")
+        if path and not path.startswith(("+", "joinchat/")):
+            return f"@{path.split('/')[0]}"
+
+    if parsed.netloc == "web.telegram.org" and parsed.fragment:
+        chat_id = parsed.fragment.strip()
+        if chat_id.startswith("-") and not chat_id.startswith("-100"):
+            return f"-100{chat_id.removeprefix('-')}"
+        return chat_id
+
+    return value

--- a/socialmedia/templates/socialmedia/organizer/account_form.html
+++ b/socialmedia/templates/socialmedia/organizer/account_form.html
@@ -44,6 +44,17 @@
                 </div>
             </form>
 
+            {% if setup_instructions %}
+            <div class="well" style="margin-top: 20px; background-color: #f7f9fa; border-left: 4px solid #337ab7;">
+                <h4><i class="fa fa-info-circle"></i> {% trans "How to connect:" %}</h4>
+                <ol style="padding-left: 20px; margin-bottom: 0;">
+                    {% for step in setup_instructions %}
+                        <li style="margin-bottom: 5px;">{{ step }}</li>
+                    {% endfor %}
+                </ol>
+            </div>
+            {% endif %}
+
             {% if object %}
             <div id="test-connection-result" style="display:none; margin-top:15px;"></div>
             {% endif %}

--- a/socialmedia/templates/socialmedia/organizer/account_form.html
+++ b/socialmedia/templates/socialmedia/organizer/account_form.html
@@ -32,12 +32,66 @@
                         <button type="submit" class="btn btn-primary">
                             {% trans "Save Connection" %}
                         </button>
+                        {% if object %}
+                        <button type="button" id="test-connection-btn" class="btn btn-info" data-account-pk="{{ object.pk }}">
+                            <i class="fa fa-plug"></i> {% trans "Test Connection" %}
+                        </button>
+                        {% endif %}
                         <a href="{% url 'plugins:socialmedia:organizer_accounts' organizer=organizer.slug %}{% if request.GET.event %}?event={{ request.GET.event }}{% endif %}" class="btn btn-default">
                             {% trans "Cancel" %}
                         </a>
                     </div>
                 </div>
             </form>
+
+            {% if object %}
+            <div id="test-connection-result" style="display:none; margin-top:15px;"></div>
+            {% endif %}
         </div>
     </div>
+
+    {% if object %}
+    <script>
+    (function() {
+        var btn = document.getElementById('test-connection-btn');
+        if (!btn) return;
+        btn.addEventListener('click', function() {
+            var pk = btn.getAttribute('data-account-pk');
+            var resultDiv = document.getElementById('test-connection-result');
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> {% trans "Testing..." %}';
+            resultDiv.style.display = 'none';
+
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', '{% url "plugins:socialmedia:organizer_account_test" organizer=organizer.slug pk=object.pk %}');
+            xhr.setRequestHeader('X-CSRFToken', '{{ csrf_token }}');
+            xhr.onload = function() {
+                var data;
+                try {
+                    data = JSON.parse(xhr.responseText);
+                } catch(e) {
+                    data = { success: false, message: "{% trans 'An unexpected server error occurred.' %}" };
+                }
+                resultDiv.style.display = 'block';
+                if (xhr.status === 200 && data.success) {
+                    resultDiv.innerHTML = '<div class="alert alert-success"><i class="fa fa-check-circle"></i> ' + data.message + '</div>';
+                } else {
+                    resultDiv.innerHTML = '<div class="alert alert-danger"><i class="fa fa-times-circle"></i> ' + data.message + '</div>';
+                }
+                btn.disabled = false;
+                btn.innerHTML = '<i class="fa fa-plug"></i> {% trans "Test Connection" %}';
+            };
+            xhr.onerror = function() {
+                resultDiv.style.display = 'block';
+                resultDiv.innerHTML = '<div class="alert alert-danger"><i class="fa fa-times-circle"></i> {% trans "Network error. Please try again." %}</div>';
+                btn.disabled = false;
+                btn.innerHTML = '<i class="fa fa-plug"></i> {% trans "Test Connection" %}';
+            };
+
+
+            xhr.send(JSON.stringify({}));
+        });
+    })();
+    </script>
+    {% endif %}
 {% endblock %}

--- a/socialmedia/urls.py
+++ b/socialmedia/urls.py
@@ -46,4 +46,9 @@ urlpatterns = [
         views.OrganizerAccountDeleteView.as_view(),
         name="organizer_account_delete",
     ),
+    path(
+        "social/organizer/<orgslug:organizer>/accounts/<int:pk>/test/",
+        views.test_connection,
+        name="organizer_account_test",
+    ),
 ]

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime
 
 import pytz
@@ -21,6 +22,8 @@ from eventyay.control.views.organizer_views.organizer_detail_view_mixin import (
 from .export import build_posts, generate_csv_from_posts, sync_posts_to_db
 from .forms import PROVIDER_FORMS, SocialMediaSettingsForm
 from .models import SocialMediaAccount, SocialMediaPost, SocialMediaPostStatus
+
+logger = logging.getLogger(__name__)
 
 
 def _check_plugin_active(request):
@@ -284,9 +287,29 @@ class OrganizerAccountCreateView(
 
     def form_valid(self, form):
         form.instance.organizer = self.request.organizer
+        self._validate_connection(form)
         response = super().form_valid(form)
         messages.success(self.request, _("Account successfully connected."))
         return response
+
+    def _validate_connection(self, form):
+        from .providers.registry import get_provider
+
+        try:
+            account = form.save(commit=False)
+            account.organizer = self.request.organizer
+            provider = get_provider(account)
+            if not provider.validate_credentials():
+                raise Exception("Credentials validation returned False.")
+        except Exception as e:
+            logger.warning(f"Connection verification failed during save: {e}")
+            messages.warning(
+                self.request,
+                _(
+                    "Credentials could not be verified. "
+                    "The account was saved but may not work."
+                ),
+            )
 
     def get_success_url(self):
         url = reverse(
@@ -317,9 +340,29 @@ class OrganizerAccountUpdateView(
         return PROVIDER_FORMS.get(provider)
 
     def form_valid(self, form):
+        self._validate_connection(form)
         response = super().form_valid(form)
         messages.success(self.request, _("Account settings updated."))
         return response
+
+    def _validate_connection(self, form):
+        from .providers.registry import get_provider
+
+        try:
+            account = form.save(commit=False)
+            account.organizer = self.request.organizer
+            provider = get_provider(account)
+            if not provider.validate_credentials():
+                raise Exception("Credentials validation returned False.")
+        except Exception as e:
+            logger.warning(f"Connection verification failed during save: {e}")
+            messages.warning(
+                self.request,
+                _(
+                    "Credentials could not be verified. "
+                    "The account was saved but may not work."
+                ),
+            )
 
     def get_success_url(self):
         url = reverse(
@@ -385,3 +428,38 @@ class OrganizerAccountDeleteView(
         if event_slug:
             url = f"{url}?event={event_slug}"
         return url
+
+
+@require_POST
+def test_connection(request, organizer, pk):
+    """AJAX POST — send a test message to verify the connection works."""
+    if not request.user.is_authenticated:
+        return JsonResponse(
+            {"success": False, "message": "Authentication required."},
+            status=403,
+        )
+    if not request.user.has_organizer_permission(
+        request.organizer, "can_change_organizer_settings", request=request
+    ):
+        return JsonResponse(
+            {"success": False, "message": "Permission denied."},
+            status=403,
+        )
+
+    account = SocialMediaAccount.objects.filter(
+        organizer=request.organizer, pk=pk
+    ).first()
+    if not account:
+        return JsonResponse(
+            {"success": False, "message": "Account not found."},
+            status=404,
+        )
+
+    try:
+        from .providers.registry import get_provider
+
+        provider = get_provider(account)
+        result = provider.send_test_message()
+        return JsonResponse(result)
+    except Exception as e:
+        return JsonResponse({"success": False, "message": str(e)}, status=500)

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -282,6 +282,17 @@ class OrganizerAccountCreateView(
             )
         return super().dispatch(request, *args, **kwargs)
 
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        from .providers.registry import get_provider_class
+
+        try:
+            provider_cls = get_provider_class(self.provider)
+            ctx["setup_instructions"] = provider_cls.get_setup_instructions()
+        except ValueError:
+            pass
+        return ctx
+
     def get_form_class(self):
         return PROVIDER_FORMS[self.provider]
 
@@ -331,6 +342,18 @@ class OrganizerAccountUpdateView(
 
     def get_object(self, queryset=None):
         return super(OrganizerDetailViewMixin, self).get_object(queryset)
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        provider = self.get_object().provider
+        from .providers.registry import get_provider_class
+
+        try:
+            provider_cls = get_provider_class(provider)
+            ctx["setup_instructions"] = provider_cls.get_setup_instructions()
+        except ValueError:
+            pass
+        return ctx
 
     def get_queryset(self):
         return SocialMediaAccount.objects.filter(organizer=self.request.organizer)

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -422,7 +422,16 @@ class OrganizerAccountDeleteView(
             scheduled_at__gt=timezone.now(),
         )
 
+        # Note: Since SocialMediaPost rows do not have a foreign key to a
+        # specific SocialMediaAccount, we filter by the provider type suffix
+        # on the entity_id (e.g. "_telegram") or general/aggregator posts.
         if account.provider in ["postiz", "buffer"]:
+            # Aggregator integrations sync general scheduled posts (not
+            # specific to direct platforms). We exclude posts that are
+            # targeted to direct platforms (telegram, mastodon, etc.).
+            direct_platforms = ["telegram", "mastodon", "twitter", "linkedin"]
+            for p in direct_platforms:
+                active_posts = active_posts.exclude(entity_id__endswith=f"_{p}")
             has_active = active_posts.exists()
             count = active_posts.count()
         else:

--- a/tests/test_organizer_accounts.py
+++ b/tests/test_organizer_accounts.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from django_scopes import scope
 from eventyay.base.models import Organizer, Team
 
+from socialmedia.forms import TelegramAccountForm
 from socialmedia.models import (
     SocialMediaAccount,
     SocialMediaPost,
@@ -142,6 +143,45 @@ def test_account_create_post(organizer_admin_client, organizer):
         assert account.is_active is True
 
 
+def test_telegram_account_form_normalizes_public_tme_link():
+    form = TelegramAccountForm(
+        data={
+            "platform_username": " t.me/mypublicchannel ",
+            "bot_token": "my_secret_bot_token",
+            "is_active": "on",
+        }
+    )
+
+    assert form.is_valid()
+    assert form.cleaned_data["platform_username"] == "@mypublicchannel"
+
+
+def test_telegram_account_form_normalizes_web_telegram_link():
+    form = TelegramAccountForm(
+        data={
+            "platform_username": "https://web.telegram.org/k/#-4482182411",
+            "bot_token": "my_secret_bot_token",
+            "is_active": "on",
+        }
+    )
+
+    assert form.is_valid()
+    assert form.cleaned_data["platform_username"] == "-1004482182411"
+
+
+def test_telegram_account_form_rejects_private_invite_link():
+    form = TelegramAccountForm(
+        data={
+            "platform_username": "https://t.me/+abcdef",
+            "bot_token": "my_secret_bot_token",
+            "is_active": "on",
+        }
+    )
+
+    assert not form.is_valid()
+    assert "platform_username" in form.errors
+
+
 @pytest.mark.django_db
 def test_account_update_view(organizer_admin_client, organizer):
     with scope(organizer=organizer):
@@ -173,6 +213,19 @@ def test_account_update_view(organizer_admin_client, organizer):
 
     account.refresh_from_db()
     assert account.platform_username == "@newchannel"
+    assert account.credentials == {"bot_token": "old_token"}
+
+    # POST with placeholder secret - should also keep old token
+    payload_placeholder = {
+        "platform_username": "@newchannel2",
+        "bot_token": "••••••••",
+        "is_active": "on",
+    }
+    response = organizer_admin_client.post(url, data=payload_placeholder)
+    assert response.status_code == 302
+
+    account.refresh_from_db()
+    assert account.platform_username == "@newchannel2"
     assert account.credentials == {"bot_token": "old_token"}
 
 

--- a/tests/test_organizer_accounts.py
+++ b/tests/test_organizer_accounts.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.urls import reverse
@@ -249,3 +249,26 @@ def test_multi_tenancy_isolation(organizer_admin_client, organizer, settings):
     # Trying to access other organizer's connection via our organizer slug
     response = organizer_admin_client.get(url)
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@patch("socialmedia.providers.telegram.TelegramProvider.send_test_message")
+def test_test_connection_view(mock_send_test, organizer_admin_client, organizer):
+    mock_send_test.return_value = {"success": True, "message": "Test message sent."}
+    with scope(organizer=organizer):
+        account = SocialMediaAccount.objects.create(
+            organizer=organizer,
+            provider="telegram",
+            platform_username="@mychannel",
+            credentials={"bot_token": "fake_token"},
+        )
+
+    url = reverse(
+        "plugins:socialmedia:organizer_account_test",
+        kwargs={"organizer": organizer.slug, "pk": account.pk},
+    )
+    response = organizer_admin_client.post(url, content_type="application/json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["message"] == "Test message sent."

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,223 @@
+from unittest.mock import MagicMock, mock_open, patch
+import pytest
+from socialmedia.models import SocialMediaAccount
+from socialmedia.providers import BaseSocialProvider, PublishingError, get_provider, get_provider_class
+from socialmedia.providers.telegram import TelegramProvider
+from socialmedia.providers.mastodon import MastodonProvider
+from socialmedia.providers.postiz import PostizProvider
+from socialmedia.providers.buffer import BufferProvider
+
+
+@pytest.fixture
+def mock_account():
+    account = MagicMock(spec=SocialMediaAccount)
+    account.provider = "telegram"
+    account.platform_username = "@testchannel"
+    account.credentials = {"bot_token": "fake_token"}
+    return account
+
+
+def test_base_provider_raises_not_implemented(mock_account):
+    provider = BaseSocialProvider(mock_account)
+    with pytest.raises(NotImplementedError):
+        provider.validate_credentials()
+    with pytest.raises(NotImplementedError):
+        provider.publish_post("text")
+    assert provider.sync_campaign([]) == []
+
+
+def test_registry_get_provider_class():
+    assert get_provider_class("telegram") == TelegramProvider
+    assert get_provider_class("mastodon") == MastodonProvider
+    assert get_provider_class("postiz") == PostizProvider
+    assert get_provider_class("buffer") == BufferProvider
+    with pytest.raises(ValueError):
+        get_provider_class("unknown")
+
+
+def test_registry_get_provider(mock_account):
+    provider = get_provider(mock_account)
+    assert isinstance(provider, TelegramProvider)
+
+
+@patch("requests.get")
+def test_telegram_validate_credentials(mock_get, mock_account):
+    provider = TelegramProvider(mock_account)
+
+    # Valid credentials
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+    mock_get.return_value = mock_response
+    assert provider.validate_credentials() is True
+
+    # Invalid credentials
+    mock_response.json.return_value = {"ok": False}
+    assert provider.validate_credentials() is False
+
+    # HTTP error
+    mock_get.side_effect = Exception("HTTP Error")
+    assert provider.validate_credentials() is False
+
+
+@patch("requests.post")
+def test_telegram_publish_post_text_only(mock_post, mock_account):
+    provider = TelegramProvider(mock_account)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True, "result": {"message_id": 123}}
+    mock_post.return_value = mock_response
+
+    res = provider.publish_post("hello world")
+    assert res["post_id"] == "123"
+    assert res["url"] == "https://t.me/testchannel/123"
+    mock_post.assert_called_once()
+
+
+@patch("builtins.open", new_callable=mock_open, read_data=b"image_data")
+@patch("requests.post")
+def test_telegram_publish_post_with_local_media(mock_post, mock_file, mock_account):
+    provider = TelegramProvider(mock_account)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True, "result": {"message_id": 456}}
+    mock_post.return_value = mock_response
+
+    res = provider.publish_post("hello with media", media=["/path/to/img.png"])
+    assert res["post_id"] == "456"
+    assert "sendPhoto" in mock_post.call_args[0][0]
+
+
+@patch("requests.post")
+def test_telegram_publish_post_with_remote_media(mock_post, mock_account):
+    provider = TelegramProvider(mock_account)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True, "result": {"message_id": 789}}
+    mock_post.return_value = mock_response
+
+    res = provider.publish_post("hello remote media", media=["https://example.com/img.png"])
+    assert res["post_id"] == "789"
+    assert "photo" in mock_post.call_args[1]["data"]
+
+
+@patch("requests.post")
+def test_telegram_publish_error(mock_post, mock_account):
+    provider = TelegramProvider(mock_account)
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.text = "Bad Request"
+    mock_post.return_value = mock_response
+
+    with pytest.raises(PublishingError):
+        provider.publish_post("hello error")
+
+
+@patch("socialmedia.providers.mastodon.Mastodon")
+def test_mastodon_validate_credentials(mock_mastodon_cls, mock_account):
+    mock_account.provider = "mastodon"
+    mock_account.credentials = {
+        "api_base_url": "https://mastodon.social",
+        "access_token": "fake_token",
+    }
+    provider = MastodonProvider(mock_account)
+
+    # Valid credentials
+    mock_client = mock_mastodon_cls.return_value
+    mock_client.account_verify_credentials.return_value = {"username": "testuser"}
+    assert provider.validate_credentials() is True
+
+    # Invalid credentials
+    mock_client.account_verify_credentials.side_effect = Exception("Invalid token")
+    assert provider.validate_credentials() is False
+
+
+@patch("socialmedia.providers.mastodon.Mastodon")
+def test_mastodon_publish_post(mock_mastodon_cls, mock_account):
+    mock_account.provider = "mastodon"
+    mock_account.credentials = {
+        "api_base_url": "https://mastodon.social",
+        "access_token": "fake_token",
+    }
+    provider = MastodonProvider(mock_account)
+    mock_client = mock_mastodon_cls.return_value
+    mock_client.status_post.return_value = {"id": 12345, "url": "https://mastodon.social/@testuser/12345"}
+
+    res = provider.publish_post("Mastodon post")
+    assert res["post_id"] == "12345"
+    assert res["url"] == "https://mastodon.social/@testuser/12345"
+
+
+@patch("requests.get")
+def test_postiz_validate_credentials(mock_get, mock_account):
+    mock_account.provider = "postiz"
+    mock_account.credentials = {
+        "api_url": "https://api.postiz.com",
+        "api_key": "fake_key",
+    }
+    provider = PostizProvider(mock_account)
+
+    # Valid
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+    assert provider.validate_credentials() is True
+
+    # Invalid
+    mock_response.status_code = 401
+    assert provider.validate_credentials() is False
+
+
+@patch("requests.post")
+def test_postiz_publish_post(mock_post, mock_account):
+    mock_account.provider = "postiz"
+    mock_account.credentials = {
+        "api_url": "https://api.postiz.com",
+        "api_key": "fake_key",
+    }
+    provider = PostizProvider(mock_account)
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"id": "postiz_123", "url": "https://postiz.com/posts/postiz_123"}
+    mock_post.return_value = mock_response
+
+    res = provider.publish_post("Postiz status")
+    assert res["post_id"] == "postiz_123"
+    assert res["url"] == "https://postiz.com/posts/postiz_123"
+
+
+@patch("requests.get")
+def test_buffer_validate_credentials(mock_get, mock_account):
+    mock_account.provider = "buffer"
+    mock_account.credentials = {
+        "access_token": "fake_token",
+    }
+    provider = BufferProvider(mock_account)
+
+    # Valid
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+    assert provider.validate_credentials() is True
+
+    # Invalid
+    mock_response.status_code = 403
+    assert provider.validate_credentials() is False
+
+
+@patch("requests.post")
+def test_buffer_publish_post(mock_post, mock_account):
+    mock_account.provider = "buffer"
+    mock_account.platform_username = "profile123"
+    mock_account.credentials = {
+        "access_token": "fake_token",
+    }
+    provider = BufferProvider(mock_account)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"updates": [{"id": "buffer_123"}]}
+    mock_post.return_value = mock_response
+
+    res = provider.publish_post("Buffer update")
+    assert res["post_id"] == "buffer_123"
+    assert "profile_ids[]" in mock_post.call_args[1]["data"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,11 +1,18 @@
 from unittest.mock import MagicMock, mock_open, patch
+
 import pytest
+
 from socialmedia.models import SocialMediaAccount
-from socialmedia.providers import BaseSocialProvider, PublishingError, get_provider, get_provider_class
-from socialmedia.providers.telegram import TelegramProvider
+from socialmedia.providers import (
+    BaseSocialProvider,
+    PublishingError,
+    get_provider,
+    get_provider_class,
+)
+from socialmedia.providers.buffer import BufferProvider
 from socialmedia.providers.mastodon import MastodonProvider
 from socialmedia.providers.postiz import PostizProvider
-from socialmedia.providers.buffer import BufferProvider
+from socialmedia.providers.telegram import TelegramProvider
 
 
 @pytest.fixture
@@ -96,7 +103,9 @@ def test_telegram_publish_post_with_remote_media(mock_post, mock_account):
     mock_response.json.return_value = {"ok": True, "result": {"message_id": 789}}
     mock_post.return_value = mock_response
 
-    res = provider.publish_post("hello remote media", media=["https://example.com/img.png"])
+    res = provider.publish_post(
+        "hello remote media", media=["https://example.com/img.png"]
+    )
     assert res["post_id"] == "789"
     assert "photo" in mock_post.call_args[1]["data"]
 
@@ -141,7 +150,10 @@ def test_mastodon_publish_post(mock_mastodon_cls, mock_account):
     }
     provider = MastodonProvider(mock_account)
     mock_client = mock_mastodon_cls.return_value
-    mock_client.status_post.return_value = {"id": 12345, "url": "https://mastodon.social/@testuser/12345"}
+    mock_client.status_post.return_value = {
+        "id": 12345,
+        "url": "https://mastodon.social/@testuser/12345",
+    }
 
     res = provider.publish_post("Mastodon post")
     assert res["post_id"] == "12345"
@@ -178,7 +190,10 @@ def test_postiz_publish_post(mock_post, mock_account):
     provider = PostizProvider(mock_account)
     mock_response = MagicMock()
     mock_response.status_code = 201
-    mock_response.json.return_value = {"id": "postiz_123", "url": "https://postiz.com/posts/postiz_123"}
+    mock_response.json.return_value = {
+        "id": "postiz_123",
+        "url": "https://postiz.com/posts/postiz_123",
+    }
     mock_post.return_value = mock_response
 
     res = provider.publish_post("Postiz status")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -47,24 +47,55 @@ def test_registry_get_provider(mock_account):
     assert isinstance(provider, TelegramProvider)
 
 
+def test_telegram_provider_normalizes_web_telegram_url(mock_account):
+    mock_account.platform_username = "https://web.telegram.org/k/#-4482182411"
+    provider = TelegramProvider(mock_account)
+
+    assert provider.chat_id == "-1004482182411"
+    assert provider._resolve_chat_id() == -1004482182411
+
+
 @patch("requests.get")
 def test_telegram_validate_credentials(mock_get, mock_account):
     provider = TelegramProvider(mock_account)
 
     # Valid credentials
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"ok": True}
-    mock_get.return_value = mock_response
+    mock_get_me_response = MagicMock()
+    mock_get_me_response.status_code = 200
+    mock_get_me_response.json.return_value = {"ok": True}
+    mock_get_chat_response = MagicMock()
+    mock_get_chat_response.status_code = 200
+    mock_get_chat_response.json.return_value = {"ok": True}
+    mock_get.side_effect = [mock_get_me_response, mock_get_chat_response]
     assert provider.validate_credentials() is True
 
     # Invalid credentials
-    mock_response.json.return_value = {"ok": False}
+    mock_get.reset_mock(side_effect=True)
+    mock_get_me_response.json.return_value = {"ok": False}
+    mock_get.return_value = mock_get_me_response
     assert provider.validate_credentials() is False
 
     # HTTP error
     mock_get.side_effect = Exception("HTTP Error")
     assert provider.validate_credentials() is False
+
+
+@patch("requests.get")
+def test_telegram_validate_credentials_checks_chat(mock_get, mock_account):
+    provider = TelegramProvider(mock_account)
+    mock_get_me_response = MagicMock()
+    mock_get_me_response.status_code = 200
+    mock_get_me_response.json.return_value = {"ok": True}
+    mock_get_chat_response = MagicMock()
+    mock_get_chat_response.status_code = 400
+    mock_get_chat_response.json.return_value = {
+        "ok": False,
+        "description": "Bad Request: chat not found",
+    }
+    mock_get.side_effect = [mock_get_me_response, mock_get_chat_response]
+
+    assert provider.validate_credentials() is False
+    assert mock_get.call_args_list[1].kwargs["params"] == {"chat_id": "@testchannel"}
 
 
 @patch("requests.post")
@@ -201,8 +232,87 @@ def test_postiz_publish_post(mock_post, mock_account):
     assert res["url"] == "https://postiz.com/posts/postiz_123"
 
 
+@patch("requests.post")
+def test_postiz_publish_post_accepts_empty_success_response(mock_post, mock_account):
+    mock_account.provider = "postiz"
+    mock_account.credentials = {
+        "api_url": "https://api.postiz.com",
+        "api_key": "fake_key",
+    }
+    provider = PostizProvider(mock_account)
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_response.text = ""
+    mock_post.return_value = mock_response
+
+    res = provider.publish_post("Postiz status")
+
+    assert res == {"post_id": "", "url": ""}
+
+
+@patch("requests.post")
 @patch("requests.get")
-def test_buffer_validate_credentials(mock_get, mock_account):
+def test_postiz_send_test_message_creates_visible_post(
+    mock_get, mock_post, mock_account
+):
+    mock_account.provider = "postiz"
+    mock_account.credentials = {
+        "api_url": "https://api.postiz.com",
+        "api_key": "fake_key",
+    }
+    provider = PostizProvider(mock_account)
+
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get.return_value = mock_get_response
+
+    mock_post_response = MagicMock()
+    mock_post_response.status_code = 201
+    mock_post_response.json.return_value = {
+        "id": "postiz_test_123",
+        "url": "https://postiz.com/posts/postiz_test_123",
+    }
+    mock_post.return_value = mock_post_response
+
+    result = provider.send_test_message()
+
+    assert result["success"] is True
+    assert "Test post created in Postiz" in result["message"]
+    assert "postiz_test_123" in result["message"]
+    assert mock_post.call_args.kwargs["json"] == {
+        "content": "✅ Connection successful from Eventyay!"
+    }
+
+
+@patch("requests.post")
+@patch("requests.get")
+def test_postiz_send_test_message_handles_empty_success_response(
+    mock_get, mock_post, mock_account
+):
+    mock_account.provider = "postiz"
+    mock_account.credentials = {
+        "api_url": "https://api.postiz.com",
+        "api_key": "fake_key",
+    }
+    provider = PostizProvider(mock_account)
+
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get.return_value = mock_get_response
+
+    mock_post_response = MagicMock()
+    mock_post_response.status_code = 204
+    mock_post_response.text = ""
+    mock_post.return_value = mock_post_response
+
+    result = provider.send_test_message()
+
+    assert result["success"] is True
+    assert "Postiz accepted the request" in result["message"]
+
+
+@patch("requests.post")
+def test_buffer_validate_credentials(mock_post, mock_account):
     mock_account.provider = "buffer"
     mock_account.credentials = {
         "access_token": "fake_token",
@@ -212,11 +322,12 @@ def test_buffer_validate_credentials(mock_get, mock_account):
     # Valid
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_get.return_value = mock_response
+    mock_response.json.return_value = {"data": {"account": {"id": "account123"}}}
+    mock_post.return_value = mock_response
     assert provider.validate_credentials() is True
 
     # Invalid
-    mock_response.status_code = 403
+    mock_response.json.return_value = {"data": {"account": None}}
     assert provider.validate_credentials() is False
 
 
@@ -230,9 +341,56 @@ def test_buffer_publish_post(mock_post, mock_account):
     provider = BufferProvider(mock_account)
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"updates": [{"id": "buffer_123"}]}
+    mock_response.json.return_value = {
+        "data": {
+            "createPost": {
+                "post": {
+                    "id": "buffer_123",
+                    "text": "Buffer update",
+                }
+            }
+        }
+    }
     mock_post.return_value = mock_response
 
     res = provider.publish_post("Buffer update")
     assert res["post_id"] == "buffer_123"
-    assert "profile_ids[]" in mock_post.call_args[1]["data"]
+    assert res["url"] == "https://publish.buffer.com/content/buffer_123"
+    query = mock_post.call_args.kwargs["json"]["query"]
+    assert 'channelId: "profile123"' in query
+    assert "saveToDraft: false" in query
+
+
+@patch("requests.post")
+def test_buffer_send_test_message_creates_draft(mock_post, mock_account):
+    mock_account.provider = "buffer"
+    mock_account.platform_username = "profile123"
+    mock_account.credentials = {
+        "access_token": "fake_token",
+    }
+    provider = BufferProvider(mock_account)
+
+    validate_response = MagicMock()
+    validate_response.status_code = 200
+    validate_response.json.return_value = {"data": {"account": {"id": "account123"}}}
+
+    draft_response = MagicMock()
+    draft_response.status_code = 200
+    draft_response.json.return_value = {
+        "data": {
+            "createPost": {
+                "post": {
+                    "id": "draft_123",
+                    "text": "✅ Connection successful from Eventyay!",
+                }
+            }
+        }
+    }
+    mock_post.side_effect = [validate_response, draft_response]
+
+    result = provider.send_test_message()
+
+    assert result["success"] is True
+    assert "Test draft created in Buffer" in result["message"]
+    query = mock_post.call_args.kwargs["json"]["query"]
+    assert "saveToDraft: true" in query

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -430,9 +430,9 @@ def test_no_platforms_fallback(organizer, event):
         posts = build_posts(event)
 
     for post in posts:
-        assert (
-            post.get("platform") is None
-        ), f"Expected no platform on post {post['id']}, got {post['platform']!r}"
+        assert post.get("platform") is None, (
+            f"Expected no platform on post {post['id']}, got {post['platform']!r}"
+        )
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -430,9 +430,9 @@ def test_no_platforms_fallback(organizer, event):
         posts = build_posts(event)
 
     for post in posts:
-        assert post.get("platform") is None, (
-            f"Expected no platform on post {post['id']}, got {post['platform']!r}"
-        )
+        assert (
+            post.get("platform") is None
+        ), f"Expected no platform on post {post['id']}, got {post['platform']!r}"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Overview
This PR implements the core interface and concrete provider adapters for direct social platforms (**Telegram**, **Mastodon**) and scheduling aggregators (**Postiz**, **Buffer**), cleanly decoupling external API network code from Django views and models. It also introduces connection verification workflows, cryptographic credential management, settings forms, and a comprehensive test suite.
- closes : #29 
---

### Key Changes

#### 1. Provider Adapter Interface
* Created [BaseSocialProvider](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/providers/base.py#L15) in `socialmedia/providers/base.py` defining standard client operations: `validate_credentials()`, `publish_post()`, `send_test_message()`, and `sync_campaign()`.

#### 2. Concrete Provider Adapters
* **Telegram**: Added [TelegramProvider](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/providers/telegram.py#L13) supporting Telegram Bot API integration. It uses Python's `requests` package to invoke `sendMessage` (text-only posts) or `sendPhoto`/`sendDocument` (local or remote media attachments) under the hood. Added normalization rules for chat/channel URLs and handles in [telegram_utils.py](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/telegram_utils.py).
* **Mastodon**: Added `MastodonProvider` in [mastodon.py](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/providers/mastodon.py) using the Python `mastodon.py` client to verify account credentials and publish statuses with media uploads.
* **Postiz**: Added `PostizProvider` in [postiz.py](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/providers/postiz.py) connecting to self-hosted API instances with authorization tokens to queue posts.
* **Buffer**: Added `BufferProvider` in [buffer.py](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/providers/buffer.py) interacting with Buffer's GraphQL API endpoints using OAuth tokens to queue updates.

#### 3. Forms and Account Management
* Defined validation and encryption rules for credential payloads in [forms.py](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/forms.py) (e.g. `TelegramAccountForm`, `MastodonAccountForm`, `PostizAccountForm`, `BufferAccountForm`).
* Integrated Fernet encryption in [crypto.py](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/crypto.py) to securely store credentials inside the database block.

#### 4. Verification & Testing
* Created comprehensive unit tests in [test_providers.py](file:///home/saalim/OSS/eventyay-socialmedia/tests/test_providers.py) using `unittest.mock` to verify mock credentials checking, success/failure paths, and file uploads across all adapters.

---

# The Provider Connection Flow

The workflow below describes how Eventyay validates credentials, saves integration details, and tests active connections:

```mermaid
sequenceDiagram
    autonumber
    actor Organizer
    participant View as Django View / Form
    participant DB as SQLite / PostgreSQL (encrypted)
    participant Crypto as crypto.py
    participant Registry as registry.py
    participant Adapter as Provider Adapter Subclass
    participant ExtAPI as Remote API (e.g., Telegram / Postiz)

    Organizer->>View: Input Bot Token, API URL, or OAuth keys
    Note over View, Crypto: Saving & Encrypting
    View->>Crypto: encrypt_credentials(data)
    Crypto-->>View: Fernet cipher text
    View->>DB: Save SocialMediaAccount
    
    Note over View, ExtAPI: Validation & Testing
    View->>DB: Fetch SocialMediaAccount
    DB-->>View: Account record
    View->>Crypto: decrypt_credentials(cipher_text)
    Crypto-->>View: Credentials dictionary
    View->>Registry: get_provider(account)
    Registry->>Adapter: Instantiate (e.g., TelegramProvider)
    View->>Adapter: validate_credentials() / send_test_message()
    Adapter->>ExtAPI: Send API request (e.g., /getMe or GraphQL Query)
    ExtAPI-->>Adapter: 200 OK / Success payload
    Adapter-->>View: Returns True or Success dict
    View-->>Organizer: Connection Successful!
```

### Detailed Steps:

1. **User Settings Submission**: 
   The Organizer fills out credentials in the provider-specific form (e.g. [TelegramAccountForm](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/forms.py#L448)).
2. **On-the-Fly Credential Encryption**: 
   Before persisting, the `SocialMediaAccount` model processes credentials via Python properties, invoking `encrypt_credentials()` from [crypto.py](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/crypto.py#L16). It uses a 32-byte Fernet key derived from the Django `SECRET_KEY` using SHA-256 to serialize the payload into secure JSON.
3. **Decryption upon Retrieval**:
   When the account record is retrieved, accessing `account.credentials` automatically calls `decrypt_credentials()`, decoding the JSON parameters back into standard dictionary keys.
4. **Adapter Resolution & Instantiation**:
   The view/controller imports [get_provider(account)](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/providers/registry.py#L34). The registry:
   * Looks up the corresponding provider class inside the central mapping registry `_registry` in `socialmedia/providers/registry.py`.
   * Spawns an instance of the specific adapter (e.g. `MastodonProvider(account)`) exposing the credentials directly to `self.credentials`.
5. **Connection Validation**:
   * **During Save**: The form calls `validate_credentials()` to make a lightweight request to the platform's authentication endpoint. If it returns `False`, a warning notification warns the user that the credentials may be incorrect.
   * **Connection Test Button**: When the user clicks the test button on the dashboard, it calls the `test_connection` view which invokes `provider.send_test_message()`. This drops a trial message (e.g. a scheduled draft or test post containing `✅ Connection successful from Eventyay!`) into the external account to visually confirm that permissions are correctly configured.