### PR TITLE
fix: scope post selections, counts, and actions to active filter

### DIFF
--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -86,13 +86,13 @@
         return this.update(id, { enabled });
       },
       selectAll(enabled) {
-        posts.forEach(p => { p.enabled = enabled; });
+        this.getFiltered().forEach(p => { p.enabled = enabled; });
       },
       applyBulkPreset(offsetDays) {
         let updatedCount = 0;
         let skippedCount = 0;
 
-        posts.forEach(p => {
+        this.getFiltered().forEach(p => {
           if (!p.enabled) return;
           if (p.reference_date) {
             p.post_date = Helpers.addDays(p.reference_date, offsetDays);
@@ -106,7 +106,7 @@
       },
       applyBulkCustom(customDate, customTime) {
         let updatedCount = 0;
-        posts.forEach(p => {
+        this.getFiltered().forEach(p => {
           if (!p.enabled) return;
           p.post_date = customDate;
           p.post_time = customTime;
@@ -116,7 +116,7 @@
       },
       applyBulkDefault() {
         let updatedCount = 0;
-        posts.forEach(p => {
+        this.getFiltered().forEach(p => {
           if (!p.enabled) return;
           p.post_date = p.original_post_date;
           p.post_time = p.original_post_time;
@@ -130,7 +130,7 @@
         let limitExceededCount = 0;
         const todayStr = Helpers.getLocalTodayStr();
 
-        posts.forEach(p => {
+        this.getFiltered().forEach(p => {
           if (!p.enabled) return;
           if (p.post_date < todayStr) pastCount++;
           if (p.post_text.includes("{") || p.post_text.includes("}")) placeholderCount++;
@@ -638,7 +638,7 @@
     },
 
     updateSelectedCount() {
-      const posts = PostState.getAll();
+      const posts = PostState.getFiltered();
       const n = posts.filter(p => p.enabled).length;
       const total = posts.length;
 
@@ -927,7 +927,7 @@
       const presetSelect = document.getElementById("export-preset-select");
       const exportFormat = presetSelect ? presetSelect.value : "generic";
 
-      APIClient.exportCSV(visiblePosts, exportFormat)
+      APIClient.exportCSV(enabledVisiblePosts, exportFormat)
         .then(blob => {
           const url = URL.createObjectURL(blob);
           const a = document.createElement("a");


### PR DESCRIPTION

### **Description**
Fixes : #35.

When an active filter tab (such as CfP, Speakers, or Tickets) was active, toggling the "Toggle All" checkbox, viewing selection counts, applying bulk presets/validation, and exporting to CSV were operating globally on all post content across the platform rather than being scoped to the currently active view/section.

### **Changes**
- **Scoped "Toggle All" and Selection Counts**:
  - Modified `PostState.selectAll()` to toggle the `enabled` state of only the visible posts returned by `this.getFiltered()` rather than all posts.
  - Updated `updateSelectedCount()` to compute total and selected post counts based on `PostState.getFiltered()`.
- **Scoped Presets and Validation**:
  - Scoped `applyBulkPreset()`, `applyBulkCustom()`, `applyBulkDefault()`, and `validate()` to only operate on enabled items within `this.getFiltered()`.
- **Scoped CSV Exports**:
  - Updated `exportCSV()` to pass only `enabledVisiblePosts` to `APIClient.exportCSV()`, preventing unchecked (disabled) posts in the current section from being exported.
  
  

https://github.com/user-attachments/assets/39d1ae9d-240d-4f1d-9ec1-ea0af6f30507

