### PR TITLE
feat: restructure UI into sidebar-navigated sections, add live card preview modal, and fix provider image publishing

### DIFF
--- a/socialmedia/providers/mastodon.py
+++ b/socialmedia/providers/mastodon.py
@@ -60,11 +60,35 @@ class MastodonProvider(BaseSocialProvider):
                     if file_path.startswith(("http://", "https://")):
                         r = safe_fetch_url(file_path, timeout=20)
                         r.raise_for_status()
-                        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+
+                        content_type = r.headers.get("content-type", "")
+                        ext = ".jpg"
+                        if "png" in content_type or file_path.lower().endswith(".png"):
+                            ext = ".png"
+                        elif "gif" in content_type or file_path.lower().endswith(
+                            ".gif"
+                        ):
+                            ext = ".gif"
+                        elif "webp" in content_type or file_path.lower().endswith(
+                            ".webp"
+                        ):
+                            ext = ".webp"
+                        elif (
+                            "jpeg" in content_type
+                            or "jpg" in content_type
+                            or file_path.lower().endswith((".jpg", ".jpeg"))
+                        ):
+                            ext = ".jpg"
+
+                        with tempfile.NamedTemporaryFile(
+                            suffix=ext, delete=False
+                        ) as tmp:
                             tmp.write(r.content)
                             tmp_path = tmp.name
                         try:
-                            res = self.client.media_post(tmp_path)
+                            res = self.client.media_post(
+                                tmp_path, mime_type=content_type or None
+                            )
                             media_ids.append(res["id"])
                         finally:
                             if os.path.exists(tmp_path):

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -9,6 +9,9 @@ from .base import BaseSocialProvider, PublishingError
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_REQUEST_TIMEOUT = 15
+MEDIA_UPLOAD_TIMEOUT = 20
+
 
 class TelegramProvider(BaseSocialProvider):
     """Telegram Bot API integration adapter."""
@@ -23,7 +26,9 @@ class TelegramProvider(BaseSocialProvider):
         if not self.token:
             return False
         try:
-            response = requests.get(f"{self.base_url}getMe", timeout=10)
+            response = requests.get(
+                f"{self.base_url}getMe", timeout=DEFAULT_REQUEST_TIMEOUT
+            )
             if response.status_code != 200 or not response.json().get("ok", False):
                 return False
 
@@ -31,7 +36,7 @@ class TelegramProvider(BaseSocialProvider):
                 response = requests.get(
                     f"{self.base_url}getChat",
                     params={"chat_id": self._resolve_chat_id()},
-                    timeout=10,
+                    timeout=DEFAULT_REQUEST_TIMEOUT,
                 )
                 return response.status_code == 200 and response.json().get("ok", False)
 
@@ -51,7 +56,9 @@ class TelegramProvider(BaseSocialProvider):
                 "chat_id": self._resolve_chat_id(),
                 "text": "✅ Connection successful from Eventyay!",
             }
-            response = requests.post(url, data=payload, timeout=15)
+            response = requests.post(
+                url, data=payload, timeout=DEFAULT_REQUEST_TIMEOUT
+            )
             if response.status_code == 200:
                 result = response.json()
                 if result.get("ok"):
@@ -93,7 +100,9 @@ class TelegramProvider(BaseSocialProvider):
 
     def _get_bot_info(self) -> str:
         try:
-            me_res = requests.get(f"{self.base_url}getMe", timeout=10)
+            me_res = requests.get(
+                f"{self.base_url}getMe", timeout=DEFAULT_REQUEST_TIMEOUT
+            )
             if me_res.status_code == 200:
                 me_data = me_res.json()
                 if me_data.get("ok"):
@@ -135,29 +144,35 @@ class TelegramProvider(BaseSocialProvider):
                 payload["caption"] = text
                 payload["parse_mode"] = "Markdown"
 
-                if is_url:
-                    try:
-                        r = requests.get(media_item, timeout=20)
-                        r.raise_for_status()
-                        content_type = r.headers.get("content-type", "image/jpeg")
-                        ext = "png" if "png" in content_type else "jpg"
-                        files = {"photo": (f"photo.{ext}", r.content, content_type)}
-                        response = requests.post(
-                            url, data=payload, files=files, timeout=20
-                        )
-                    except Exception as download_err:
-                        logger.warning(
-                            "Could not download photo locally (%s)",
-                            download_err,
-                        )
-                        payload["photo"] = media_item
-                        response = requests.post(url, data=payload, timeout=20)
-                else:
-                    with open(media_item, "rb") as f:
-                        files = {"photo": f}
-                        response = requests.post(
-                            url, data=payload, files=files, timeout=20
-                        )
+                def _do_send_photo(current_payload: dict[str, Any]) -> requests.Response:
+                    if is_url:
+                        try:
+                            r = requests.get(media_item, timeout=MEDIA_UPLOAD_TIMEOUT)
+                            r.raise_for_status()
+                            content_type = r.headers.get("content-type", "image/jpeg")
+                            ext = "png" if "png" in content_type else "jpg"
+                            files = {"photo": (f"photo.{ext}", r.content, content_type)}
+                            return requests.post(
+                                url, data=current_payload, files=files, timeout=MEDIA_UPLOAD_TIMEOUT
+                            )
+                        except Exception as download_err:
+                            logger.warning(
+                                "Could not download photo locally (%s)",
+                                download_err,
+                            )
+                            photo_payload = dict(current_payload)
+                            photo_payload["photo"] = media_item
+                            return requests.post(
+                                url, data=photo_payload, timeout=MEDIA_UPLOAD_TIMEOUT
+                            )
+                    else:
+                        with open(media_item, "rb") as f:
+                            files = {"photo": f}
+                            return requests.post(
+                                url, data=current_payload, files=files, timeout=MEDIA_UPLOAD_TIMEOUT
+                            )
+
+                response = _do_send_photo(payload)
 
                 # Retry without parse_mode if Markdown formatting check failed
                 if (
@@ -165,12 +180,7 @@ class TelegramProvider(BaseSocialProvider):
                     and "can't parse entities" in response.text.lower()
                 ):
                     payload.pop("parse_mode", None)
-                    if is_url and "files" in locals():
-                        response = requests.post(
-                            url, data=payload, files=files, timeout=20
-                        )
-                    else:
-                        response = requests.post(url, data=payload, timeout=20)
+                    response = _do_send_photo(payload)
             else:
                 url = f"{self.base_url}sendMessage"
                 payload.update(
@@ -179,13 +189,17 @@ class TelegramProvider(BaseSocialProvider):
                         "parse_mode": "Markdown",
                     }
                 )
-                response = requests.post(url, data=payload, timeout=15)
+                response = requests.post(
+                    url, data=payload, timeout=DEFAULT_REQUEST_TIMEOUT
+                )
                 if (
                     response.status_code != 200
                     and "can't parse entities" in response.text.lower()
                 ):
                     payload.pop("parse_mode", None)
-                    response = requests.post(url, data=payload, timeout=15)
+                    response = requests.post(
+                        url, data=payload, timeout=DEFAULT_REQUEST_TIMEOUT
+                    )
 
             if response.status_code != 200:
                 raise PublishingError(f"Telegram API error: {response.text}")

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -131,29 +131,46 @@ class TelegramProvider(BaseSocialProvider):
                 media_item = media[0]
                 is_url = media_item.startswith(("http://", "https://"))
 
+                url = f"{self.base_url}sendPhoto"
+                payload["caption"] = text
+                payload["parse_mode"] = "Markdown"
+
                 if is_url:
-                    url = f"{self.base_url}sendPhoto"
-                    payload.update(
-                        {
-                            "photo": media_item,
-                            "caption": text,
-                            "parse_mode": "Markdown",
-                        }
-                    )
-                    response = requests.post(url, data=payload, timeout=15)
+                    try:
+                        r = requests.get(media_item, timeout=20)
+                        r.raise_for_status()
+                        content_type = r.headers.get("content-type", "image/jpeg")
+                        ext = "png" if "png" in content_type else "jpg"
+                        files = {"photo": (f"photo.{ext}", r.content, content_type)}
+                        response = requests.post(
+                            url, data=payload, files=files, timeout=20
+                        )
+                    except Exception as download_err:
+                        logger.warning(
+                            "Could not download photo locally (%s)",
+                            download_err,
+                        )
+                        payload["photo"] = media_item
+                        response = requests.post(url, data=payload, timeout=20)
                 else:
-                    url = f"{self.base_url}sendPhoto"
-                    payload.update(
-                        {
-                            "caption": text,
-                            "parse_mode": "Markdown",
-                        }
-                    )
                     with open(media_item, "rb") as f:
                         files = {"photo": f}
                         response = requests.post(
                             url, data=payload, files=files, timeout=20
                         )
+
+                # Retry without parse_mode if Markdown formatting check failed
+                if (
+                    response.status_code != 200
+                    and "can't parse entities" in response.text.lower()
+                ):
+                    payload.pop("parse_mode", None)
+                    if is_url and "files" in locals():
+                        response = requests.post(
+                            url, data=payload, files=files, timeout=20
+                        )
+                    else:
+                        response = requests.post(url, data=payload, timeout=20)
             else:
                 url = f"{self.base_url}sendMessage"
                 payload.update(
@@ -163,6 +180,12 @@ class TelegramProvider(BaseSocialProvider):
                     }
                 )
                 response = requests.post(url, data=payload, timeout=15)
+                if (
+                    response.status_code != 200
+                    and "can't parse entities" in response.text.lower()
+                ):
+                    payload.pop("parse_mode", None)
+                    response = requests.post(url, data=payload, timeout=15)
 
             if response.status_code != 200:
                 raise PublishingError(f"Telegram API error: {response.text}")

--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -122,7 +122,6 @@ def control_nav_event_common_socialmedia(sender, request=None, **kwargs):
     ]
 
 
-
 @receiver(event_dashboard_components, dispatch_uid="socialmedia_dashboard_components")
 def control_dashboard_socialmedia(sender, request=None, **kwargs):
     return render_to_string(

--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -80,22 +80,47 @@ def control_nav_event_common_socialmedia(sender, request=None, **kwargs):
     ):
         return []
     url = resolve(request.path_info)
+    in_sm = url.namespace == "plugins:socialmedia"
+
+    posts_url = reverse(
+        "plugins:socialmedia:posts",
+        kwargs={"organizer": sender.organizer.slug, "event": sender.slug},
+    )
+    settings_url = reverse(
+        "plugins:socialmedia:plugin_settings",
+        kwargs={"organizer": sender.organizer.slug, "event": sender.slug},
+    )
+    log_url = reverse(
+        "plugins:socialmedia:log",
+        kwargs={"organizer": sender.organizer.slug, "event": sender.slug},
+    )
+
     return [
         {
             "label": str(_("Social Media")),
-            "url": reverse(
-                "plugins:socialmedia:index",
-                kwargs={
-                    "organizer": sender.organizer.slug,
-                    "event": sender.slug,
-                },
-            ),
+            "url": posts_url,
             "icon": "share-alt",
-            "active": (
-                url.namespace == "plugins:socialmedia" and url.url_name == "index"
-            ),
+            "active": in_sm and url.url_name in ("index", "posts"),
+            "children": [
+                {
+                    "label": _("Posts"),
+                    "url": posts_url,
+                    "active": in_sm and url.url_name in ("index", "posts"),
+                },
+                {
+                    "label": _("Settings"),
+                    "url": settings_url,
+                    "active": in_sm and url.url_name == "plugin_settings",
+                },
+                {
+                    "label": _("Publishing Log"),
+                    "url": log_url,
+                    "active": in_sm and url.url_name == "log",
+                },
+            ],
         }
     ]
+
 
 
 @receiver(event_dashboard_components, dispatch_uid="socialmedia_dashboard_components")

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -1041,3 +1041,125 @@ body .sm-toast i {
   background: #e7f5ff;
   color: #1062a6;
 }
+
+/* ---- Preview Button & Character Warnings ---- */
+.btn-preview-post {
+  background: none;
+  border: none;
+  color: #495057;
+  padding: 4px 8px;
+  font-size: 14px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+  margin-right: 4px;
+}
+.btn-preview-post:hover {
+  background: #f1f3f5;
+  color: #111;
+}
+
+.char-count.over-limit {
+  color: #d9534f;
+  font-weight: 700;
+}
+.char-count-wrap .over-limit-badge {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 11px;
+  color: #d9534f;
+  font-weight: 600;
+}
+
+/* ---- Card Preview Modal Mockup ---- */
+.sm-card-modal .modal-content {
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+}
+
+.sm-card-preview {
+  background: #ffffff;
+  border: 1px solid #e9ecef;
+  border-radius: 12px;
+  padding: 18px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+.sm-preview-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.sm-preview-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #e9ecef;
+  border: 1px solid #dee2e6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #adb5bd;
+  font-size: 20px;
+}
+.sm-preview-author {
+  font-weight: 700;
+  color: #212529;
+  font-size: 15px;
+  line-height: 1.2;
+}
+.sm-preview-handle {
+  font-size: 13px;
+  color: #6c757d;
+  font-weight: 400;
+}
+.sm-preview-platform-tag {
+  margin-left: auto;
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.sm-preview-text {
+  font-size: 14px;
+  line-height: 1.5;
+  color: #212529;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-bottom: 12px;
+}
+.sm-preview-media {
+  margin: 14px auto;
+  width: 180px;
+  height: 180px;
+  aspect-ratio: 1 / 1;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 2px solid #e9ecef;
+  background: #f8f9fa;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+.sm-preview-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sm-preview-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 1px solid #f1f3f5;
+  font-size: 12px;
+  color: #6c757d;
+}

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -751,20 +751,9 @@
 
       const avatar = document.createElement("div");
       avatar.className = "sm-preview-avatar";
-      if (post.media_url) {
-        const img = document.createElement("img");
-        img.src = post.media_url;
-        img.alt = "Attachment Preview";
-        img.style.width = "100%";
-        img.style.height = "100%";
-        img.style.borderRadius = "50%";
-        img.style.objectFit = "cover";
-        avatar.appendChild(img);
-      } else {
-        const icon = document.createElement("i");
-        icon.className = meta.iconClass || "fa fa-user";
-        avatar.appendChild(icon);
-      }
+      const icon = document.createElement("i");
+      icon.className = meta.iconClass || "fa fa-user";
+      avatar.appendChild(icon);
       header.appendChild(avatar);
 
       const authorBox = document.createElement("div");

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -650,6 +650,14 @@
         this.setWithIcon(restoreBtn, "", "fa fa-undo");
         tdActions.appendChild(restoreBtn);
       } else {
+        const prevBtn = document.createElement("button");
+        prevBtn.className = "btn-preview-post";
+        prevBtn.dataset.postId = p.id;
+        prevBtn.type = "button";
+        prevBtn.title = "Preview post live card";
+        this.setWithIcon(prevBtn, "", "fa fa-eye");
+        tdActions.appendChild(prevBtn);
+
         if (p.status !== "published" && p.status !== "exported") {
           const pubBtn = document.createElement("button");
           pubBtn.className = "btn-publish-now";
@@ -723,6 +731,127 @@
       tbody.appendChild(fragment);
 
       this.updateSelectedCount();
+    },
+
+    openPreviewModal(post) {
+      const container = document.getElementById("sm-card-preview-container");
+      if (!container || !post) return;
+      container.textContent = "";
+
+      const platformKey = post.platform || "generic";
+      const meta = PLATFORM_META[platformKey] || { label: "Generic Post", iconClass: "fa fa-share-alt", colorClass: "plat-generic" };
+      const limit = PLATFORM_LIMITS[platformKey] || null;
+
+      const previewBox = document.createElement("div");
+      previewBox.className = "sm-card-preview";
+
+      // Header
+      const header = document.createElement("div");
+      header.className = "sm-preview-header";
+
+      const avatar = document.createElement("div");
+      avatar.className = "sm-preview-avatar";
+      if (post.media_url) {
+        const img = document.createElement("img");
+        img.src = post.media_url;
+        img.alt = "Attachment Preview";
+        img.style.width = "100%";
+        img.style.height = "100%";
+        img.style.borderRadius = "50%";
+        img.style.objectFit = "cover";
+        avatar.appendChild(img);
+      } else {
+        const icon = document.createElement("i");
+        icon.className = meta.iconClass || "fa fa-user";
+        avatar.appendChild(icon);
+      }
+      header.appendChild(avatar);
+
+      const authorBox = document.createElement("div");
+      const nameDiv = document.createElement("div");
+      nameDiv.className = "sm-preview-author";
+      nameDiv.textContent = post.event_name || "Event Official";
+      const handleDiv = document.createElement("div");
+      handleDiv.className = "sm-preview-handle";
+      handleDiv.textContent = `@eventyay_${platformKey}`;
+      authorBox.appendChild(nameDiv);
+      authorBox.appendChild(handleDiv);
+      header.appendChild(authorBox);
+
+      const tag = document.createElement("span");
+      tag.className = `sm-preview-platform-tag platform-badge ${meta.colorClass || ''}`;
+      tag.textContent = meta.label;
+      header.appendChild(tag);
+
+      previewBox.appendChild(header);
+
+      // Body Text
+      const textDiv = document.createElement("div");
+      textDiv.className = "sm-preview-text";
+      textDiv.textContent = post.post_text;
+      previewBox.appendChild(textDiv);
+
+      // Media Attachment (if media_url exists)
+      if (post.media_url) {
+        const mediaBox = document.createElement("div");
+        mediaBox.className = "sm-preview-media";
+        const mediaImg = document.createElement("img");
+        mediaImg.src = post.media_url;
+        mediaImg.alt = "Post Media Attachment";
+        mediaBox.appendChild(mediaImg);
+        previewBox.appendChild(mediaBox);
+      }
+
+      // Footer / Char Counter
+      const footer = document.createElement("div");
+      footer.className = "sm-preview-footer";
+
+      const timeSpan = document.createElement("span");
+      timeSpan.textContent = `Scheduled: ${post.post_date} at ${post.post_time}`;
+      footer.appendChild(timeSpan);
+
+      const charSpan = document.createElement("span");
+      const exceeds = limit && post.post_text.length > limit;
+      charSpan.className = exceeds ? "char-count over-limit" : "char-count";
+      charSpan.textContent = limit ? `${post.post_text.length} / ${limit} chars` : `${post.post_text.length} chars`;
+      footer.appendChild(charSpan);
+
+      previewBox.appendChild(footer);
+      container.appendChild(previewBox);
+
+      // Bind modal publish now button
+      const modalPubBtn = document.getElementById("btn-modal-publish-now");
+      const modalEl = document.getElementById("sm-preview-modal");
+      
+      const hideModal = () => {
+        const $jq = window.$ || window.jQuery;
+        if ($jq && typeof $jq.fn.modal === "function") {
+          $jq("#sm-preview-modal").modal("hide");
+        } else if (modalEl) {
+          modalEl.style.display = "none";
+          modalEl.classList.remove("in");
+        }
+      };
+
+      if (modalPubBtn) {
+        if (post.db_id && post.status !== "published" && post.status !== "exported") {
+          modalPubBtn.style.display = "inline-block";
+          modalPubBtn.onclick = () => {
+            hideModal();
+            AppController.publishPostNow(post.id, post.db_id, null);
+          };
+        } else {
+          modalPubBtn.style.display = "none";
+        }
+      }
+
+      const $jq = window.$ || window.jQuery;
+      if ($jq && typeof $jq.fn.modal === "function") {
+        $jq("#sm-preview-modal").modal("show");
+      } else if (modalEl) {
+        modalEl.style.display = "block";
+        modalEl.classList.add("in");
+      }
     },
 
     updateCounts() {
@@ -1180,9 +1309,6 @@
       const btnRegen = document.getElementById("btn-regenerate");
       if (btnRegen) btnRegen.addEventListener("click", () => this.loadInitialData());
 
-      const btnSaveRegen = document.getElementById("btn-save-regenerate");
-      if (btnSaveRegen) btnSaveRegen.addEventListener("click", (e) => this.saveAndRegenerate(e));
-
       const filterPills = document.getElementById("filter-pills");
       if (filterPills) {
         filterPills.addEventListener("click", (e) => {
@@ -1281,6 +1407,11 @@
 
               APIClient.updatePostStatus(post, "scheduled");
               UI.showToast("Post restored to preview.", "success");
+            }
+          } else if (e.target.closest(".btn-preview-post")) {
+            const post = PostState.get(postId);
+            if (post) {
+              UI.openPreviewModal(post);
             }
           } else if (e.target.closest(".btn-publish-now")) {
             const btn = e.target.closest(".btn-publish-now");

--- a/socialmedia/templates/socialmedia/log.html
+++ b/socialmedia/templates/socialmedia/log.html
@@ -1,0 +1,151 @@
+{% extends "eventyay_common/event/base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Social Media — Publishing Log" %} :: {{ event.name }}{% endblock %}
+
+{% block content %}
+<link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+
+<div class="sm-page">
+  <div class="sm-toolbar">
+    <h1>
+      {% trans "Publishing Log" %}
+      <small>{{ event.name }}</small>
+    </h1>
+  </div>
+
+  <!-- Status filter tabs -->
+  <div class="sm-filters" id="log-filter-pills">
+    <a href="?status=" class="sm-filter-btn {% if not status_filter %}active{% endif %}">
+      {% trans "All" %} <span class="count">{{ total_count }}</span>
+    </a>
+    <a href="?status=published" class="sm-filter-btn {% if status_filter == 'published' %}active{% endif %}">
+      {% trans "Published" %} <span class="count">{{ published_count }}</span>
+    </a>
+    <a href="?status=exported" class="sm-filter-btn {% if status_filter == 'exported' %}active{% endif %}">
+      {% trans "Exported" %} <span class="count">{{ exported_count }}</span>
+    </a>
+    <a href="?status=failed" class="sm-filter-btn {% if status_filter == 'failed' %}active{% endif %}">
+      {% trans "Failed" %} <span class="count">{{ failed_count }}</span>
+    </a>
+    <a href="?status=scheduled" class="sm-filter-btn {% if status_filter == 'scheduled' %}active{% endif %}">
+      {% trans "Scheduled" %} <span class="count">{{ scheduled_count }}</span>
+    </a>
+  </div>
+
+  <!-- Log table -->
+  <div class="sm-table-wrap">
+    <table class="sm-table">
+      <thead>
+        <tr>
+          <th>{% trans "Type" %}</th>
+          <th>{% trans "Platform" %}</th>
+          <th>{% trans "Content Preview" %}</th>
+          <th>{% trans "Scheduled At" %}</th>
+          <th>{% trans "Last Updated" %}</th>
+          <th>{% trans "Status" %}</th>
+          <th>{% trans "Error" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for post in posts %}
+        <tr>
+          <td>
+            <span class="sm-type-badge sm-type-{{ post.post_type|lower }}">
+              {{ post.get_post_type_display|default:post.post_type|capfirst }}
+            </span>
+          </td>
+          <td>
+            {% if post.entity_id %}
+              {% for platform in platforms %}
+                {% if platform in post.entity_id %}
+                  <span class="sm-platform-badge sm-platform-{{ platform }}">
+                    {% if platform == "telegram" %}<i class="fa fa-paper-plane"></i>{% endif %}
+                    {% if platform == "mastodon" %}<i class="fa fa-bullhorn"></i>{% endif %}
+                    {% if platform == "twitter" %}<i class="fa fa-twitter"></i>{% endif %}
+                    {% if platform == "linkedin" %}<i class="fa fa-linkedin"></i>{% endif %}
+                    {{ platform|capfirst }}
+                  </span>
+                {% endif %}
+              {% endfor %}
+            {% else %}
+              <span class="sm-platform-badge">{% trans "Generic" %}</span>
+            {% endif %}
+          </td>
+          <td class="sm-log-content">
+            {{ post.post_text|truncatechars:80 }}
+          </td>
+          <td>
+            {% if post.scheduled_at %}
+              {{ post.scheduled_at|date:"M d, Y" }}<br>
+              <small class="text-muted">{{ post.scheduled_at|date:"H:i" }}</small>
+            {% else %}
+              <span class="text-muted">—</span>
+            {% endif %}
+          </td>
+          <td>
+            {{ post.updated_at|date:"M d, Y" }}<br>
+            <small class="text-muted">{{ post.updated_at|date:"H:i" }}</small>
+          </td>
+          <td>
+            <span class="sm-status-badge sm-status-{{ post.status }}">
+              {% if post.status == "published" %}
+                <i class="fa fa-check-circle"></i> {% trans "Published" %}
+              {% elif post.status == "exported" %}
+                <i class="fa fa-cloud-upload"></i> {% trans "Exported" %}
+              {% elif post.status == "failed" %}
+                <i class="fa fa-times-circle"></i> {% trans "Failed" %}
+              {% elif post.status == "scheduled" %}
+                <i class="fa fa-clock-o"></i> {% trans "Scheduled" %}
+              {% elif post.status == "draft" %}
+                <i class="fa fa-pencil"></i> {% trans "Draft" %}
+              {% else %}
+                {{ post.status|capfirst }}
+              {% endif %}
+            </span>
+          </td>
+          <td>
+            {% if post.error_message %}
+              <span class="sm-error-tooltip" title="{{ post.error_message }}">
+                <i class="fa fa-exclamation-triangle text-danger"></i>
+                <span class="sm-error-text">{{ post.error_message|truncatechars:60 }}</span>
+              </span>
+            {% else %}
+              <span class="text-muted">—</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="7" class="text-center text-muted" style="padding: 40px;">
+            <i class="fa fa-inbox fa-2x" style="display:block;margin-bottom:8px;opacity:0.4;"></i>
+            {% trans "No posts found for this filter." %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Pagination -->
+  {% if posts.has_other_pages %}
+  <div style="text-align:center; margin-top: 20px;">
+    <ul class="pagination">
+      {% if posts.has_previous %}
+        <li><a href="?page={{ posts.previous_page_number }}{% if status_filter %}&status={{ status_filter }}{% endif %}">&laquo;</a></li>
+      {% endif %}
+      {% for num in posts.paginator.page_range %}
+        <li {% if posts.number == num %}class="active"{% endif %}>
+          <a href="?page={{ num }}{% if status_filter %}&status={{ status_filter }}{% endif %}">{{ num }}</a>
+        </li>
+      {% endfor %}
+      {% if posts.has_next %}
+        <li><a href="?page={{ posts.next_page_number }}{% if status_filter %}&status={{ status_filter }}{% endif %}">&raquo;</a></li>
+      {% endif %}
+    </ul>
+  </div>
+  {% endif %}
+
+</div><!-- /sm-page -->
+{% endblock %}

--- a/socialmedia/templates/socialmedia/posts.html
+++ b/socialmedia/templates/socialmedia/posts.html
@@ -1,0 +1,150 @@
+{% extends "eventyay_common/event/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% load static %}
+
+{% block title %}{% trans "Social Media — Posts" %} :: {{ event.name }}{% endblock %}
+
+{% block content %}
+<link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+
+<div class="sm-page">
+
+  <!-- Toolbar -->
+  <div class="sm-toolbar">
+    <h1>
+      {% trans "Social Media Posts" %}
+      <small>{{ event.name }}</small>
+    </h1>
+    <a href="{% url 'plugins:socialmedia:organizer_accounts' organizer=event.organizer.slug %}?event={{ event.slug }}" class="btn btn-default">
+      <i class="fa fa-share-alt"></i> {% trans "Manage Social Accounts" %}
+    </a>
+    <button id="btn-regenerate" class="btn btn-default">
+      <i class="fa fa-refresh"></i> {% trans "Regenerate" %}
+    </button>
+  </div>
+
+  <!-- Filter pills -->
+  <div class="sm-filters" id="filter-pills">
+    <button class="sm-filter-btn active" data-type="all">
+      {% trans "All" %} <span class="count" id="cnt-all">0</span>
+    </button>
+    <button class="sm-filter-btn" data-type="cfp">
+      {% trans "CFP" %} <span class="count" id="cnt-cfp">0</span>
+    </button>
+    <button class="sm-filter-btn" data-type="speaker">
+      {% trans "Speakers" %} <span class="count" id="cnt-speaker">0</span>
+    </button>
+    <button class="sm-filter-btn" data-type="session">
+      {% trans "Sessions" %} <span class="count" id="cnt-session">0</span>
+    </button>
+    <button class="sm-filter-btn" data-type="ticket">
+      {% trans "Tickets" %} <span class="count" id="cnt-ticket">0</span>
+    </button>
+    <button class="sm-filter-btn" data-type="schedule">
+      {% trans "Schedule" %} <span class="count" id="cnt-schedule">0</span>
+    </button>
+    <button class="sm-filter-btn" data-type="excluded">
+      {% trans "Excluded" %} <span class="count" id="cnt-excluded">0</span>
+    </button>
+  </div>
+
+  <!-- Action bar -->
+  <div class="sm-actions">
+
+    <!-- Bulk schedule preset dropdown -->
+    <div class="bulk-schedule-wrap">
+      <select id="bulk-schedule-preset" class="form-control input-sm bulk-schedule-select">
+        <option value="">{% trans "Schedule preset..." %}</option>
+        <option value="default">{% trans "Revert to default timing" %}</option>
+        <option value="0">{% trans "On event / session day" %}</option>
+        <option value="-1">{% trans "1 day before" %}</option>
+        <option value="-2">{% trans "2 days before" %}</option>
+        <option value="-3">{% trans "3 days before" %}</option>
+        <option value="-5">{% trans "5 days before" %}</option>
+        <option value="-7">{% trans "1 week before (7 days)" %}</option>
+        <option value="-14">{% trans "2 weeks before (14 days)" %}</option>
+        <option value="-30">{% trans "1 month before (30 days)" %}</option>
+        <option value="custom">{% trans "Custom..." %}</option>
+      </select>
+      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs" style="display: none; align-items: center; gap: 4px;">
+        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm" style="width: 130px; display: inline-block;">
+        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" style="width: 100px; display: inline-block;" value="09:00">
+      </div>
+      <button id="btn-apply-schedule" class="btn btn-default btn-sm" type="button">
+        {% trans "Apply" %}
+      </button>
+    </div>
+    <span class="sm-count" id="selected-count">–</span>
+  </div>
+
+  <div id="validation-alert-container" style="display: none; margin-bottom: 12px;"></div>
+
+  <!-- Post table -->
+  <div class="sm-table-wrap">
+    <table class="sm-table">
+      <thead>
+        <tr>
+          <th><input type="checkbox" id="chk-all" title="{% trans 'Toggle all' %}"></th>
+          <th>{% trans "Type" %}</th>
+          <th>{% trans "Platform" %}</th>
+          <th><span title="{% trans 'Official date & time of the session on the event agenda schedule.' %}" class="help-tooltip">{% trans "Schedule Date & Time" %}</span></th>
+          <th>
+            <span title="{% trans 'The date & time this social media post is scheduled to be published.' %}" class="help-tooltip">{% trans "Post Date & Time" %}</span>
+            <div class="th-timezone">{{ event.timezone }}</div>
+          </th>
+          <th>{% trans "Content" %} <span class="th-hint">— {% trans "click to edit" %}</span></th>
+          <th>{% trans "Actions" %}</th>
+        </tr>
+      </thead>
+      <tbody id="posts-tbody">
+        <!-- Skeleton rows -->
+        {% for i in "12345" %}
+        <tr class="skeleton-row">
+          <td><div class="skeleton-bar skeleton-col-check"></div></td>
+          <td><div class="skeleton-bar skeleton-col-type"></div></td>
+          <td><div class="skeleton-bar skeleton-col-platform"></div></td>
+          <td><div class="skeleton-bar skeleton-col-date"></div></td>
+          <td><div class="skeleton-bar skeleton-col-postdate"></div></td>
+          <td><div class="skeleton-bar skeleton-col-content"></div></td>
+          <td><div class="skeleton-bar skeleton-col-actions"></div></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Export bar (below table, right-aligned) -->
+  <div class="export-bar">
+    <span class="selected-count" id="export-count">0 {% trans "posts selected" %}</span>
+    <div style="display: inline-flex; align-items: center; gap: 8px;">
+      <select id="export-preset-select" class="form-control input-sm" style="width: 150px; display: inline-block;">
+        <option value="generic">{% trans "Generic CSV" %}</option>
+        <option value="postiz">{% trans "Postiz CSV" %}</option>
+        <option value="buffer">{% trans "Buffer CSV" %}</option>
+        <option value="hootsuite">{% trans "Hootsuite CSV" %}</option>
+      </select>
+      <button id="btn-export" class="btn btn-primary btn-export">
+        <i class="fa fa-download"></i> {% trans "Export CSV" %}
+      </button>
+      <button id="btn-sync-schedulers" class="btn btn-success" type="button">
+        <i class="fa fa-refresh"></i> {% trans "Sync to Schedulers" %}
+      </button>
+    </div>
+  </div>
+
+</div><!-- /sm-page -->
+<script id="socialmedia-config" type="application/json">
+  {
+    "previewUrl": "{{ preview_url }}",
+    "exportUrl": "{{ export_url }}",
+    "updateUrl": "{{ update_url }}",
+    "syncUrl": "{% url 'plugins:socialmedia:sync' organizer=organizer.slug event=event.slug %}",
+    "publishNowUrl": "{% url 'plugins:socialmedia:publish_now' organizer=organizer.slug event=event.slug %}",
+    "csrfToken": "{{ csrf_token }}",
+    "transSelectAtLeastOne": "{% trans 'Please select at least one post to export.' %}",
+    "transClickToEdit": "{% trans 'Click to edit · Ctrl+Enter to save' %}"
+  }
+</script>
+<script src="{% static 'socialmedia/js/settings.js' %}"></script>
+{% endblock %}

--- a/socialmedia/templates/socialmedia/posts.html
+++ b/socialmedia/templates/socialmedia/posts.html
@@ -131,6 +131,29 @@
         <i class="fa fa-refresh"></i> {% trans "Sync to Schedulers" %}
       </button>
     </div>
+  <!-- Live Card Preview Modal -->
+  <div class="modal fade" id="sm-preview-modal" tabindex="-1" role="dialog" aria-labelledby="sm-preview-modal-label">
+    <div class="modal-dialog modal-md" role="document">
+      <div class="modal-content sm-card-modal">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="sm-preview-modal-label">
+            <i class="fa fa-eye"></i> {% trans "Post Live Preview" %}
+          </h4>
+        </div>
+        <div class="modal-body">
+          <div id="sm-card-preview-container">
+            <!-- Dynamic card mockup inserted by JS -->
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>
+          <button type="button" class="btn btn-primary" id="btn-modal-publish-now">
+            <i class="fa fa-paper-plane"></i> {% trans "Publish Now" %}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 
 </div><!-- /sm-page -->
@@ -139,8 +162,8 @@
     "previewUrl": "{{ preview_url }}",
     "exportUrl": "{{ export_url }}",
     "updateUrl": "{{ update_url }}",
-    "syncUrl": "{% url 'plugins:socialmedia:sync' organizer=organizer.slug event=event.slug %}",
-    "publishNowUrl": "{% url 'plugins:socialmedia:publish_now' organizer=organizer.slug event=event.slug %}",
+    "syncUrl": "{% url 'plugins:socialmedia:sync' organizer=event.organizer.slug event=event.slug %}",
+    "publishNowUrl": "{% url 'plugins:socialmedia:publish_now' organizer=event.organizer.slug event=event.slug %}",
     "csrfToken": "{{ csrf_token }}",
     "transSelectAtLeastOne": "{% trans 'Please select at least one post to export.' %}",
     "transClickToEdit": "{% trans 'Click to edit · Ctrl+Enter to save' %}"

--- a/socialmedia/templates/socialmedia/settings_form.html
+++ b/socialmedia/templates/socialmedia/settings_form.html
@@ -1,0 +1,312 @@
+{% extends "eventyay_common/event/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% load static %}
+
+{% block title %}{% trans "Social Media — Settings" %} :: {{ event.name }}{% endblock %}
+
+{% block content %}
+<link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+
+<div class="sm-page">
+  <div class="sm-toolbar">
+    <h1>
+      {% trans "Social Media Settings" %}
+      <small>{{ event.name }}</small>
+    </h1>
+  </div>
+
+  <form action="" method="post" class="form-horizontal">
+    {% csrf_token %}
+    {% bootstrap_form_errors form %}
+
+    <!-- Platforms -->
+    <div class="adv-group">
+      <div class="adv-group-title"><i class="fa fa-share-alt"></i> {% trans "Platforms" %}</div>
+      <p class="adv-group-desc">
+        {% trans "Enable the platforms you post to. Each enabled platform generates its own draft row in the preview table with a platform-specific default template. Leave all disabled to generate a single generic draft per content item." %}
+      </p>
+
+      <div class="platform-toggles">
+        <!-- Twitter / X -->
+        <div class="platform-block" id="platform-block-twitter">
+          <div class="platform-block-header">
+            {% bootstrap_field form.socialmedia_twitter_enabled layout="horizontal" %}
+          </div>
+          <div class="platform-block-templates" id="plat-tpls-twitter">
+            {% bootstrap_field form.socialmedia_twitter_cfp_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_twitter_speaker_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_twitter_session_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_twitter_ticket_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_twitter_schedule_template layout="horizontal" %}
+          </div>
+        </div>
+
+        <!-- LinkedIn -->
+        <div class="platform-block" id="platform-block-linkedin">
+          <div class="platform-block-header">
+            {% bootstrap_field form.socialmedia_linkedin_enabled layout="horizontal" %}
+          </div>
+          <div class="platform-block-templates" id="plat-tpls-linkedin">
+            {% bootstrap_field form.socialmedia_linkedin_cfp_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_linkedin_speaker_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_linkedin_session_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_linkedin_ticket_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_linkedin_schedule_template layout="horizontal" %}
+          </div>
+        </div>
+
+        <!-- Telegram -->
+        <div class="platform-block" id="platform-block-telegram">
+          <div class="platform-block-header">
+            {% bootstrap_field form.socialmedia_telegram_enabled layout="horizontal" %}
+          </div>
+          <div class="platform-block-templates" id="plat-tpls-telegram">
+            {% bootstrap_field form.socialmedia_telegram_cfp_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_telegram_speaker_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_telegram_session_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_telegram_ticket_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_telegram_schedule_template layout="horizontal" %}
+          </div>
+        </div>
+
+        <!-- Mastodon -->
+        <div class="platform-block" id="platform-block-mastodon">
+          <div class="platform-block-header">
+            {% bootstrap_field form.socialmedia_mastodon_enabled layout="horizontal" %}
+          </div>
+          <div class="platform-block-templates" id="plat-tpls-mastodon">
+            {% bootstrap_field form.socialmedia_mastodon_cfp_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_mastodon_speaker_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_mastodon_session_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_mastodon_ticket_template layout="horizontal" %}
+            {% bootstrap_field form.socialmedia_mastodon_schedule_template layout="horizontal" %}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Global -->
+    <div class="adv-group">
+      <div class="adv-group-title"><i class="fa fa-globe"></i> {% trans "Global" %}</div>
+      {% bootstrap_field form.socialmedia_event_link layout="horizontal" %}
+      {% bootstrap_field form.socialmedia_default_hashtags layout="horizontal" %}
+    </div>
+
+    <!-- CFP -->
+    <div class="adv-group">
+      <div class="adv-group-title"><i class="fa fa-bullhorn"></i> {% trans "CFP" %}</div>
+      {% bootstrap_field form.socialmedia_cfp_enabled layout="horizontal" %}
+      {% bootstrap_field form.socialmedia_cfp_offset layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="presets-container" data-target="id_socialmedia_cfp_offset" data-unit="{% trans 'days' %}">
+            <span class="presets-label">{% trans "Quick Presets:" %}</span>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="30">30d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="14">14d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="7">7d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="3">3d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="1">1d</button>
+            <span class="live-offsets-preview"></span>
+          </div>
+        </div>
+      </div>
+      <div class="default-template-preview">
+        <strong>{% trans "Default templates per wave:" %}</strong>
+        <div class="wave-template-list">
+          <div class="wave-template-item"><span class="wave-label">{% trans "30+ days:" %}</span> {{ form.default_template_preview.cfp.announcement }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "3–29 days:" %}</span> {{ form.default_template_preview.cfp.reminder }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "0–2 days:" %}</span> {{ form.default_template_preview.cfp.final_call }}</div>
+        </div>
+      </div>
+      {% bootstrap_field form.socialmedia_cfp_template layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="tokens-container">
+            <span class="tokens-label">{% trans "Insert Placeholders:" %}</span>
+            <span class="token-chip" data-target="id_socialmedia_cfp_template">{event_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_cfp_template">{cfp_deadline}</span>
+            <span class="token-chip" data-target="id_socialmedia_cfp_template">{cfp_link}</span>
+            <span class="token-chip" data-target="id_socialmedia_cfp_template">{hashtags}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Speaker -->
+    <div class="adv-group">
+      <div class="adv-group-title"><i class="fa fa-user"></i> {% trans "Speaker" %}</div>
+      {% bootstrap_field form.socialmedia_speaker_enabled layout="horizontal" %}
+      {% bootstrap_field form.socialmedia_speaker_offset layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="presets-container" data-target="id_socialmedia_speaker_offset" data-unit="{% trans 'days' %}">
+            <span class="presets-label">{% trans "Quick Presets:" %}</span>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="30">30d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="14">14d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="7">7d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="3">3d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="1">1d</button>
+            <span class="live-offsets-preview"></span>
+          </div>
+        </div>
+      </div>
+      <div class="default-template-preview">
+        <strong>{% trans "Default templates per wave:" %}</strong>
+        <div class="wave-template-list">
+          <div class="wave-template-item"><span class="wave-label">{% trans "14+ days:" %}</span> {{ form.default_template_preview.speaker.announcement }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "3–13 days:" %}</span> {{ form.default_template_preview.speaker.reminder }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "0–2 days:" %}</span> {{ form.default_template_preview.speaker.final_call }}</div>
+        </div>
+      </div>
+      {% bootstrap_field form.socialmedia_speaker_template layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="tokens-container">
+            <span class="tokens-label">{% trans "Insert Placeholders:" %}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{event_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_link}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{talk_title}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{hashtags}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Session -->
+    <div class="adv-group">
+      <div class="adv-group-title"><i class="fa fa-calendar"></i> {% trans "Session" %}</div>
+      {% bootstrap_field form.socialmedia_session_enabled layout="horizontal" %}
+      {% bootstrap_field form.socialmedia_session_offset layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="presets-container" data-target="id_socialmedia_session_offset" data-unit="{% trans 'min' %}">
+            <span class="presets-label">{% trans "Quick Presets:" %}</span>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="1440">1440m</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="120">120m</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="60">60m</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="30">30m</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="15">15m</button>
+            <span class="live-offsets-preview"></span>
+          </div>
+        </div>
+      </div>
+      <div class="default-template-preview">
+        <strong>{% trans "Default templates per wave:" %}</strong>
+        <div class="wave-template-list">
+          <div class="wave-template-item"><span class="wave-label">{% trans "1440+ min:" %}</span> {{ form.default_template_preview.session.announcement }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "60–1439 min:" %}</span> {{ form.default_template_preview.session.reminder }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "0–59 min:" %}</span> {{ form.default_template_preview.session.final_call }}</div>
+        </div>
+      </div>
+      {% bootstrap_field form.socialmedia_session_template layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="tokens-container">
+            <span class="tokens-label">{% trans "Insert Placeholders:" %}</span>
+            <span class="token-chip" data-target="id_socialmedia_session_template">{event_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_session_template">{talk_title}</span>
+            <span class="token-chip" data-target="id_socialmedia_session_template">{talk_room}</span>
+            <span class="token-chip" data-target="id_socialmedia_session_template">{talk_start_time}</span>
+            <span class="token-chip" data-target="id_socialmedia_session_template">{speaker_names}</span>
+            <span class="token-chip" data-target="id_socialmedia_session_template">{talk_link}</span>
+            <span class="token-chip" data-target="id_socialmedia_session_template">{hashtags}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Ticket -->
+    <div class="adv-group">
+      <div class="adv-group-title"><i class="fa fa-ticket"></i> {% trans "Ticket" %}</div>
+      {% bootstrap_field form.socialmedia_ticket_enabled layout="horizontal" %}
+      {% bootstrap_field form.socialmedia_ticket_offset layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="presets-container" data-target="id_socialmedia_ticket_offset" data-unit="{% trans 'days' %}">
+            <span class="presets-label">{% trans "Quick Presets:" %}</span>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="30">30d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="14">14d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="7">7d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="5">5d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="1">1d</button>
+            <span class="live-offsets-preview"></span>
+          </div>
+        </div>
+      </div>
+      <div class="default-template-preview">
+        <strong>{% trans "Default templates per wave:" %}</strong>
+        <div class="wave-template-list">
+          <div class="wave-template-item"><span class="wave-label">{% trans "14+ days:" %}</span> {{ form.default_template_preview.ticket.announcement }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "3–13 days:" %}</span> {{ form.default_template_preview.ticket.reminder }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "0–2 days:" %}</span> {{ form.default_template_preview.ticket.final_call }}</div>
+        </div>
+      </div>
+      {% bootstrap_field form.socialmedia_ticket_template layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="tokens-container">
+            <span class="tokens-label">{% trans "Insert Placeholders:" %}</span>
+            <span class="token-chip" data-target="id_socialmedia_ticket_template">{event_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_ticket_template">{ticket_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_ticket_template">{ticket_price}</span>
+            <span class="token-chip" data-target="id_socialmedia_ticket_template">{ticket_link}</span>
+            <span class="token-chip" data-target="id_socialmedia_ticket_template">{hashtags}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Schedule -->
+    <div class="adv-group">
+      <div class="adv-group-title"><i class="fa fa-list-alt"></i> {% trans "Schedule" %}</div>
+      {% bootstrap_field form.socialmedia_schedule_enabled layout="horizontal" %}
+      {% bootstrap_field form.socialmedia_schedule_offset layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="presets-container" data-target="id_socialmedia_schedule_offset" data-unit="{% trans 'days' %}">
+            <span class="presets-label">{% trans "Quick Presets:" %}</span>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="14">14d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="7">7d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="3">3d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="2">2d</button>
+            <button type="button" class="btn btn-default btn-xs preset-btn" data-val="1">1d</button>
+            <span class="live-offsets-preview"></span>
+          </div>
+        </div>
+      </div>
+      <div class="default-template-preview">
+        <strong>{% trans "Default templates per wave:" %}</strong>
+        <div class="wave-template-list">
+          <div class="wave-template-item"><span class="wave-label">{% trans "7+ days:" %}</span> {{ form.default_template_preview.schedule.announcement }}</div>
+          <div class="wave-template-item"><span class="wave-label">{% trans "0–6 days:" %}</span> {{ form.default_template_preview.schedule.reminder }}</div>
+        </div>
+      </div>
+      {% bootstrap_field form.socialmedia_schedule_template layout="horizontal" %}
+      <div class="form-group helper-row">
+        <div class="col-md-9 col-md-offset-3">
+          <div class="tokens-container">
+            <span class="tokens-label">{% trans "Insert Placeholders:" %}</span>
+            <span class="token-chip" data-target="id_socialmedia_schedule_template">{event_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_schedule_template">{schedule_link}</span>
+            <span class="token-chip" data-target="id_socialmedia_schedule_template">{hashtags}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="padding-top: 10px; border-top: 1px solid #eee; display:flex; gap:10px;">
+      <button type="submit" class="btn btn-primary">
+        <i class="fa fa-save"></i> {% trans "Save Settings" %}
+      </button>
+      <button type="button" id="btn-save-regenerate" class="btn btn-default">
+        <i class="fa fa-refresh"></i> {% trans "Save & Regenerate Preview" %}
+      </button>
+    </div>
+  </form>
+
+</div><!-- /sm-page -->
+<link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+<script src="{% static 'socialmedia/js/settings.js' %}"></script>
+{% endblock %}

--- a/socialmedia/templates/socialmedia/settings_form.html
+++ b/socialmedia/templates/socialmedia/settings_form.html
@@ -297,10 +297,10 @@
     </div>
 
     <div style="padding-top: 10px; border-top: 1px solid #eee; display:flex; gap:10px;">
-      <button type="submit" class="btn btn-primary">
+      <button type="submit" name="action" value="save" class="btn btn-primary">
         <i class="fa fa-save"></i> {% trans "Save Settings" %}
       </button>
-      <button type="button" id="btn-save-regenerate" class="btn btn-default">
+      <button type="submit" name="action" value="save_and_preview" class="btn btn-default" id="btn-save-regenerate">
         <i class="fa fa-refresh"></i> {% trans "Save & Regenerate Preview" %}
       </button>
     </div>

--- a/socialmedia/urls.py
+++ b/socialmedia/urls.py
@@ -17,21 +17,18 @@ urlpatterns = [
         views.SocialMediaSettingsView.as_view(),
         name="posts",
     ),
-
     # ── Settings form ─────────────────────────────────────────────────────────
     path(
         "social/event/<orgslug:organizer>/<slug:event>/settings/",
         views.SocialMediaPostSettingsView.as_view(),
         name="plugin_settings",
     ),
-
     # ── Publishing log ────────────────────────────────────────────────────────
     path(
         "social/event/<orgslug:organizer>/<slug:event>/log/",
         views.PublishingLogView.as_view(),
         name="log",
     ),
-
     # ── AJAX endpoints ────────────────────────────────────────────────────────
     path(
         "social/event/<orgslug:organizer>/<slug:event>/preview/",
@@ -58,7 +55,6 @@ urlpatterns = [
         views.publish_post_now,
         name="publish_now",
     ),
-
     # ── Organizer-level account management ────────────────────────────────────
     path(
         "social/organizer/<orgslug:organizer>/accounts/",

--- a/socialmedia/urls.py
+++ b/socialmedia/urls.py
@@ -6,11 +6,33 @@ from . import views
 app_name = "socialmedia"
 
 urlpatterns = [
+    # ── Main landing → Posts table ────────────────────────────────────────────
     path(
         "social/event/<orgslug:organizer>/<slug:event>/",
         views.SocialMediaSettingsView.as_view(),
-        name="index",
+        name="index",  # kept for backwards compat (nav signal, old links)
     ),
+    path(
+        "social/event/<orgslug:organizer>/<slug:event>/posts/",
+        views.SocialMediaSettingsView.as_view(),
+        name="posts",
+    ),
+
+    # ── Settings form ─────────────────────────────────────────────────────────
+    path(
+        "social/event/<orgslug:organizer>/<slug:event>/settings/",
+        views.SocialMediaPostSettingsView.as_view(),
+        name="plugin_settings",
+    ),
+
+    # ── Publishing log ────────────────────────────────────────────────────────
+    path(
+        "social/event/<orgslug:organizer>/<slug:event>/log/",
+        views.PublishingLogView.as_view(),
+        name="log",
+    ),
+
+    # ── AJAX endpoints ────────────────────────────────────────────────────────
     path(
         "social/event/<orgslug:organizer>/<slug:event>/preview/",
         views.preview_posts,
@@ -36,6 +58,8 @@ urlpatterns = [
         views.publish_post_now,
         name="publish_now",
     ),
+
+    # ── Organizer-level account management ────────────────────────────────────
     path(
         "social/organizer/<orgslug:organizer>/accounts/",
         views.OrganizerAccountsListView.as_view(),

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -87,7 +87,7 @@ class SocialMediaSettingsView(DecoupleMixin, FormView):
 
     def get_success_url(self):
         return reverse(
-            "plugins:socialmedia:posts",
+            "plugins:socialmedia:index",
             kwargs={
                 "organizer": self.request.event.organizer.slug,
                 "event": self.request.event.slug,
@@ -97,6 +97,7 @@ class SocialMediaSettingsView(DecoupleMixin, FormView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["event"] = self.request.event
+        ctx["organizer"] = self.request.event.organizer
         ctx["preview_url"] = reverse(
             "plugins:socialmedia:preview",
             kwargs={
@@ -190,6 +191,17 @@ class SocialMediaPostSettingsView(DecoupleMixin, FormView):
             )
         sync_posts_to_db(self.request.event, self.request)
         messages.success(self.request, _("Your changes have been saved."))
+
+        if self.request.POST.get("action") == "save_and_preview":
+            return redirect(
+                reverse(
+                    "plugins:socialmedia:posts",
+                    kwargs={
+                        "organizer": self.request.event.organizer.slug,
+                        "event": self.request.event.slug,
+                    },
+                )
+            )
         return super().form_valid(form)
 
     def form_invalid(self, form):
@@ -230,11 +242,15 @@ class PublishingLogView(DecoupleMixin, FormView):
         valid_statuses = ["published", "exported", "failed", "scheduled", "draft"]
 
         with scope(event=request.event):
-            qs = SocialMediaPost.objects.filter(
-                event=request.event,
-            ).exclude(
-                status=SocialMediaPostStatus.DRAFT,
-            ).order_by("-updated_at")
+            qs = (
+                SocialMediaPost.objects.filter(
+                    event=request.event,
+                )
+                .exclude(
+                    status=SocialMediaPostStatus.DRAFT,
+                )
+                .order_by("-updated_at")
+            )
 
             if status_filter in valid_statuses:
                 qs = qs.filter(status=status_filter)
@@ -245,10 +261,16 @@ class PublishingLogView(DecoupleMixin, FormView):
             )
             counts = {
                 "total": all_qs.count(),
-                "published": all_qs.filter(status=SocialMediaPostStatus.PUBLISHED).count(),
-                "exported": all_qs.filter(status=SocialMediaPostStatus.EXPORTED).count(),
+                "published": all_qs.filter(
+                    status=SocialMediaPostStatus.PUBLISHED
+                ).count(),
+                "exported": all_qs.filter(
+                    status=SocialMediaPostStatus.EXPORTED
+                ).count(),
                 "failed": all_qs.filter(status=SocialMediaPostStatus.FAILED).count(),
-                "scheduled": all_qs.filter(status=SocialMediaPostStatus.SCHEDULED).count(),
+                "scheduled": all_qs.filter(
+                    status=SocialMediaPostStatus.SCHEDULED
+                ).count(),
             }
 
             paginator = Paginator(qs, 50)
@@ -803,6 +825,17 @@ def publish_post_now(request, organizer, event):
             db_post = SocialMediaPost.objects.filter(
                 entity_id=str(post_id), event=request.event
             ).first()
+
+        if not db_post:
+            sync_posts_to_db(request.event, request)
+            if db_id:
+                db_post = SocialMediaPost.objects.filter(
+                    pk=db_id, event=request.event
+                ).first()
+            if not db_post and post_id:
+                db_post = SocialMediaPost.objects.filter(
+                    entity_id=str(post_id), event=request.event
+                ).first()
 
         if not db_post:
             return JsonResponse(

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import pytz
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.core.paginator import Paginator
 from django.db import transaction
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import redirect
@@ -62,14 +63,14 @@ def _check_permission(request):
 
 class SocialMediaSettingsView(DecoupleMixin, FormView):
     """
-    Plugin settings + live post preview page.
+    Posts table page — the main Social Media section landing page.
 
     Deliberately does NOT inherit from EventSettingsViewMixin (control panel)
     so that the common-sidebar layout is preserved.
     """
 
     form_class = SocialMediaSettingsForm
-    template_name = "socialmedia/settings.html"
+    template_name = "socialmedia/posts.html"
 
     def dispatch(self, request, *args, **kwargs):
         if not request.user.is_authenticated:
@@ -86,7 +87,7 @@ class SocialMediaSettingsView(DecoupleMixin, FormView):
 
     def get_success_url(self):
         return reverse(
-            "plugins:socialmedia:index",
+            "plugins:socialmedia:posts",
             kwargs={
                 "organizer": self.request.event.organizer.slug,
                 "event": self.request.event.slug,
@@ -139,6 +140,134 @@ class SocialMediaSettingsView(DecoupleMixin, FormView):
             _("We could not save your changes. See below for details."),
         )
         return super().form_invalid(form)
+
+
+class SocialMediaPostSettingsView(DecoupleMixin, FormView):
+    """
+    Dedicated Settings page — platform toggles, templates, offsets, hashtags.
+    Lives at /social/event/<org>/<event>/settings/
+    """
+
+    form_class = SocialMediaSettingsForm
+    template_name = "socialmedia/settings_form.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            raise PermissionDenied()
+        _check_plugin_active(request)
+        _check_permission(request)
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["obj"] = self.request.event
+        return kwargs
+
+    def get_success_url(self):
+        return reverse(
+            "plugins:socialmedia:plugin_settings",
+            kwargs={
+                "organizer": self.request.event.organizer.slug,
+                "event": self.request.event.slug,
+            },
+        )
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["event"] = self.request.event
+        ctx["organizer"] = self.request.event.organizer
+        return ctx
+
+    @transaction.atomic
+    def form_valid(self, form):
+        self._save_decoupled(form)
+        form.save()
+        if form.has_changed():
+            self.request.event.log_action(
+                "eventyay.event.settings",
+                user=self.request.user,
+                data={k: form.cleaned_data.get(k) for k in form.changed_data},
+            )
+        sync_posts_to_db(self.request.event, self.request)
+        messages.success(self.request, _("Your changes have been saved."))
+        return super().form_valid(form)
+
+    def form_invalid(self, form):
+        messages.error(
+            self.request,
+            _("We could not save your changes. See below for details."),
+        )
+        return super().form_invalid(form)
+
+
+class PublishingLogView(DecoupleMixin, FormView):
+    """
+    Publishing history log page.
+    Shows all SocialMediaPost records that are not in draft state,
+    ordered by most recently updated, with status filtering and pagination.
+    Lives at /social/event/<org>/<event>/log/
+    """
+
+    form_class = SocialMediaSettingsForm  # needed by DecoupleMixin
+    template_name = "socialmedia/log.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            raise PermissionDenied()
+        _check_plugin_active(request)
+        _check_permission(request)
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["obj"] = self.request.event
+        return kwargs
+
+    def get(self, request, *args, **kwargs):
+        from django_scopes import scope
+
+        status_filter = request.GET.get("status", "")
+        valid_statuses = ["published", "exported", "failed", "scheduled", "draft"]
+
+        with scope(event=request.event):
+            qs = SocialMediaPost.objects.filter(
+                event=request.event,
+            ).exclude(
+                status=SocialMediaPostStatus.DRAFT,
+            ).order_by("-updated_at")
+
+            if status_filter in valid_statuses:
+                qs = qs.filter(status=status_filter)
+
+            # Count per status for tab badges
+            all_qs = SocialMediaPost.objects.filter(event=request.event).exclude(
+                status=SocialMediaPostStatus.DRAFT
+            )
+            counts = {
+                "total": all_qs.count(),
+                "published": all_qs.filter(status=SocialMediaPostStatus.PUBLISHED).count(),
+                "exported": all_qs.filter(status=SocialMediaPostStatus.EXPORTED).count(),
+                "failed": all_qs.filter(status=SocialMediaPostStatus.FAILED).count(),
+                "scheduled": all_qs.filter(status=SocialMediaPostStatus.SCHEDULED).count(),
+            }
+
+            paginator = Paginator(qs, 50)
+            page_number = request.GET.get("page", 1)
+            page_obj = paginator.get_page(page_number)
+
+        return self.render_to_response(
+            self.get_context_data(
+                posts=page_obj,
+                status_filter=status_filter,
+                total_count=counts["total"],
+                published_count=counts["published"],
+                exported_count=counts["exported"],
+                failed_count=counts["failed"],
+                scheduled_count=counts["scheduled"],
+                platforms=["telegram", "mastodon", "twitter", "linkedin"],
+                event=request.event,
+            )
+        )
 
 
 def preview_posts(request, organizer, event):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -126,6 +126,30 @@ def test_telegram_publish_post_with_local_media(mock_post, mock_file, mock_accou
     assert "sendPhoto" in mock_post.call_args[0][0]
 
 
+@patch("builtins.open", new_callable=mock_open, read_data=b"image_data")
+@patch("requests.post")
+def test_telegram_publish_post_local_media_markdown_retry(
+    mock_post, mock_file, mock_account
+):
+    provider = TelegramProvider(mock_account)
+    err_response = MagicMock()
+    err_response.status_code = 400
+    err_response.text = "Bad Request: can't parse entities"
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.json.return_value = {"ok": True, "result": {"message_id": 999}}
+
+    mock_post.side_effect = [err_response, ok_response]
+
+    res = provider.publish_post("hello *bad markdown*", media=["/path/to/img.png"])
+    assert res["post_id"] == "999"
+    assert mock_post.call_count == 2
+    retry_call = mock_post.call_args_list[1]
+    assert "files" in retry_call[1]
+    assert "parse_mode" not in retry_call[1]["data"]
+
+
 @patch("requests.post")
 def test_telegram_publish_post_with_remote_media(mock_post, mock_account):
     provider = TelegramProvider(mock_account)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -635,6 +635,27 @@ def test_sync_posts_to_db_saves_media_url(organizer, event):
 
         post = db_posts.first()
         assert post.media_url == "https://testserver/speaker.jpg"
+        with patch(
+            "socialmedia.export.build_posts",
+            return_value=[
+                {
+                    "id": sub.pk,
+                    "type": "speaker",
+                    "post_date": "2026-07-28",
+                    "post_time": "12:00",
+                    "post_text": "Talk by speaker2",
+                    "offset_days": 0,
+                    "media_url": "https://testserver/speaker.jpg",
+                }
+            ],
+        ):
+            sync_posts_to_db(event)
+
+        db_posts = SocialMediaPost.objects.filter(event=event, post_type="speaker")
+        assert db_posts.exists()
+
+        post = db_posts.first()
+        assert post.media_url == "https://testserver/speaker.jpg"
 
         # Verify re-syncing preserves existing media_url if payload omits it
         with patch(


### PR DESCRIPTION
## Summary
This PR restructures the Social Media plugin UI into dedicated sidebar-navigated sections (**Posts**, **Settings**, and **Publishing Log**), introduces a high-fidelity **Live Card Preview Modal**, implements character length validation, and fixes provider-specific image upload failures for **Telegram** and **Mastodon**.



https://github.com/user-attachments/assets/27c06768-347b-47c9-a2fa-d346a7f89ea4




---

##  Key Improvements & Features

### 1.  Sidebar Navigation Restructure
- **Multi-Section Navigation**: Replaced the monolithic single page with an expandable sidebar navigation group containing:
  -  **Posts** (`/posts/`): Interactive preview table, status filters, manual publishing controls, CSV export, and bulk scheduling.
  -  **Settings** (`/settings/`): Standalone form for platform toggles, custom templates, wave offsets, and hashtags.
  -  **Publishing Log** (`/log/`): Comprehensive audit history displaying historical post states (`Published`, `Exported`, `Failed`, `Scheduled`) with error tooltips and pagination.
- **Form Action Handling**: Updating templates/offsets with **Save & Regenerate Preview** saves settings, syncs database records, and automatically redirects to the Posts table.

---

### 2.  Live Social Media Card Preview Modal
- Added an **Eye (Preview)** icon button (👁️) to every row in the Posts table.
- Opens a responsive mock card modal rendering:
  - Platform brand header (Telegram, Mastodon, Twitter/X, LinkedIn).
  - Speaker profile image attachment preview formatted in a 1:1 aspect ratio.
  - Post copy text formatting and hashtags.
  - Live character count meter.
  - Direct **Publish Now** trigger inside the modal.

---

### 3. Instant On-The-Fly Manual Publishing
- Fixed `"Post not found"` error when clicking **Publish Now** on unsaved preview draft rows.
- Updated `publish_post_now` in `views.py` to automatically sync/persist unsaved draft posts to the database on the fly before executing delivery.
- Paper-plane ✈️ button is now visible on all active post rows.

---

### 4. 🛠️ Provider Image Upload & Permission Fixes
- **Mastodon (`mastodon.py`)**: Fixed `Could not determine mime type` error by extracting MIME types from HTTP `Content-Type` headers/URL extensions and passing explicit suffix extensions (`.jpg`, `.png`, `.webp`, `.gif`) to temporary files and `media_post`.
- **Telegram (`telegram.py`)**: Fixed `Bad Request: wrong HTTP URL specified` error on local/private media URLs by downloading image bytes locally and uploading photo files via binary multipart form data (`files={"photo": ...}`). Added automatic fallback retry without `parse_mode` on Markdown syntax errors.
- **Permission Guard**: Added dynamic `HAS_SOCIAL_MEDIA_PERM = hasattr(Team, "can_manage_social_media")` fallback guard across `signals.py` and `views.py`.

---

##  Testing & Verification

1. **Sidebar & Section Navigation**:
   - Navigate between **Posts**, **Settings**, and **Publishing Log** in the event control panel.
   - Edit template settings and click **Save & Regenerate Preview** → Verifies redirect to Posts with updated previews.
2. **Live Preview & Image Publishing**:
   - Click 👁️ **Preview** on any speaker row → Verifies profile picture renders in a centered 1:1 square card.
   - Click ✈️ **Publish Now** → Verifies successful delivery to Telegram & Mastodon without MIME or HTTP URL errors.

- closes : #42 