### PR TITLE
fix: include nested template and static directories in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,11 @@ include-package-data = true
 [tool.setuptools.package-data]
 socialmedia = [
     "templates/socialmedia/*.html",
+    "templates/socialmedia/*/*.html",
     "static/socialmedia/css/*.css",
+    "static/socialmedia/css/*/*.css",
     "static/socialmedia/js/*.js",
+    "static/socialmedia/js/*/*.js",
     "locale/*/LC_MESSAGES/*.po",
     "locale/*/LC_MESSAGES/*.mo",
 ]


### PR DESCRIPTION
## Description
Fixes a `500 Internal Server Error` (`TemplateDoesNotExist: socialmedia/organizer/accounts.html`) on upstream deployment when opening `/social/organizer/<slug>/accounts/`.

### Changes
Updated `pyproject.toml` to include nested subdirectories for templates and static assets:
- `templates/socialmedia/*/*.html`
- `static/socialmedia/css/*/*.css`
- `static/socialmedia/js/*/*.js`

