### PR TITLE
fix(ui): add top margin to organizer back button and eliminate inline CSS

### DIFF
--- a/socialmedia/static/socialmedia/css/dashboard.css
+++ b/socialmedia/static/socialmedia/css/dashboard.css
@@ -1,0 +1,45 @@
+/* Styles for Social Media Dashboard landing page */
+
+.sm-dashboard-header {
+  margin-bottom: 25px;
+}
+
+.sm-dashboard-title {
+  font-size: 28px;
+  margin-top: 10px;
+  margin-bottom: 5px;
+  font-weight: 700;
+  color: #333;
+}
+
+.sm-dashboard-subtitle {
+  font-size: 16px;
+  color: #777;
+  font-weight: normal;
+  margin-left: 5px;
+}
+
+.sm-dashboard-description {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 0;
+}
+
+.sm-dashboard-card {
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.sm-dashboard-card-body {
+  padding: 30px;
+  text-align: center;
+}
+
+.sm-dashboard-icon {
+  margin-bottom: 15px;
+}
+
+.sm-dashboard-text {
+  max-width: 500px;
+  margin: 0 auto 20px;
+}

--- a/socialmedia/static/socialmedia/css/organizer.css
+++ b/socialmedia/static/socialmedia/css/organizer.css
@@ -1,0 +1,25 @@
+/* Styles for Organizer Social Media settings pages */
+
+.sm-organizer-header-actions {
+  margin-top: 10px;
+}
+
+.sm-setup-instructions {
+  margin-top: 20px;
+  background-color: #f7f9fa;
+  border-left: 4px solid #337ab7;
+}
+
+.sm-setup-instructions-list {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.sm-setup-instructions-item {
+  margin-bottom: 5px;
+}
+
+.sm-test-connection-result {
+  display: none;
+  margin-top: 15px;
+}

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -1163,3 +1163,47 @@ body .sm-toast i {
   font-size: 12px;
   color: #6c757d;
 }
+
+/* Bulk schedule & export helpers */
+#bulk-schedule-custom-inputs {
+  display: none;
+}
+
+#bulk-schedule-custom-date {
+  width: 130px;
+  display: inline-block;
+}
+
+#bulk-schedule-custom-time {
+  width: 100px;
+  display: inline-block;
+}
+
+#validation-alert-container {
+  display: none;
+  margin-bottom: 12px;
+}
+
+.sm-export-preset-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#export-preset-select {
+  width: 150px;
+  display: inline-block;
+}
+
+.sm-preset-hint {
+  font-size: 12px;
+  font-weight: 400;
+  color: #aaa;
+}
+
+.sm-preview-actions {
+  padding-top: 10px;
+  border-top: 1px solid #eee;
+  display: flex;
+  gap: 10px;
+}

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -1167,6 +1167,8 @@ body .sm-toast i {
 /* Bulk schedule & export helpers */
 #bulk-schedule-custom-inputs {
   display: none;
+  align-items: center;
+  gap: 4px;
 }
 
 #bulk-schedule-custom-date {

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -1342,7 +1342,7 @@
       const customInputs = document.getElementById("bulk-schedule-custom-inputs");
       if (presetSel && customInputs) {
         presetSel.addEventListener("change", function () {
-          customInputs.classList.toggle("hidden", this.value !== "custom");
+          customInputs.style.display = this.value === "custom" ? "inline-flex" : "none";
         });
       }
 

--- a/socialmedia/templates/socialmedia/index.html
+++ b/socialmedia/templates/socialmedia/index.html
@@ -1,23 +1,26 @@
 {% extends "eventyay_common/base.html" %}
 {% load i18n %}
+{% load static %}
 {% block title %}{% trans "Social Media Dashboard" %} :: {{ event.name }}{% endblock %}
 
 {% block content %}
-    <div style="margin-bottom: 25px;">
-        <h1 style="font-size: 28px; margin-top: 10px; margin-bottom: 5px; font-weight: 700; color: #333;">
+    <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/dashboard.css' %}">
+
+    <div class="sm-dashboard-header">
+        <h1 class="sm-dashboard-title">
             {% trans "Social Media Dashboard" %}
-            <small style="font-size: 16px; color: #777; font-weight: normal; margin-left: 5px;">{{ event.name }}</small>
+            <small class="sm-dashboard-subtitle">{{ event.name }}</small>
         </h1>
-        <p style="font-size: 14px; color: #666; margin-bottom: 0;">
+        <p class="sm-dashboard-description">
             {% trans "Social Media automation plugin is successfully enabled for this event." %}
         </p>
     </div>
 
-    <div class="panel panel-default" style="border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);">
-        <div class="panel-body" style="padding: 30px; text-align: center;">
-            <i class="fa fa-share-alt fa-5x text-info" style="margin-bottom: 15px;"></i>
+    <div class="panel panel-default sm-dashboard-card">
+        <div class="panel-body sm-dashboard-card-body">
+            <i class="fa fa-share-alt fa-5x text-info sm-dashboard-icon"></i>
             <h3>{% trans "Social Media Plugin Active" %}</h3>
-            <p class="text-muted" style="max-width: 500px; margin: 0 auto 20px;">
+            <p class="text-muted sm-dashboard-text">
                 {% trans "The plugin foundation is set up. You can now configure this plugin or proceed with further development of social account connections and announcement scheduling." %}
             </p>
         </div>

--- a/socialmedia/templates/socialmedia/index.html
+++ b/socialmedia/templates/socialmedia/index.html
@@ -3,8 +3,11 @@
 {% load static %}
 {% block title %}{% trans "Social Media Dashboard" %} :: {{ event.name }}{% endblock %}
 
-{% block content %}
+{% block custom_header %}
     <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/dashboard.css' %}">
+{% endblock %}
+
+{% block content %}
 
     <div class="sm-dashboard-header">
         <h1 class="sm-dashboard-title">

--- a/socialmedia/templates/socialmedia/log.html
+++ b/socialmedia/templates/socialmedia/log.html
@@ -4,8 +4,11 @@
 
 {% block title %}{% trans "Social Media — Publishing Log" %} :: {{ event.name }}{% endblock %}
 
-{% block content %}
+{% block custom_header %}
 <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+{% endblock %}
+
+{% block content %}
 
 <div class="sm-page">
   <div class="sm-toolbar">

--- a/socialmedia/templates/socialmedia/organizer/account_form.html
+++ b/socialmedia/templates/socialmedia/organizer/account_form.html
@@ -12,8 +12,11 @@
     :: {{ organizer.name }}
 {% endblock %}
 
-{% block inner %}
+{% block custom_header %}
     <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/organizer.css' %}">
+{% endblock %}
+
+{% block inner %}
 
     <h1>
         {% if object %}

--- a/socialmedia/templates/socialmedia/organizer/account_form.html
+++ b/socialmedia/templates/socialmedia/organizer/account_form.html
@@ -1,6 +1,7 @@
 {% extends "eventyay_common/organizers/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load static %}
 
 {% block title %}
     {% if object %}
@@ -12,6 +13,8 @@
 {% endblock %}
 
 {% block inner %}
+    <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/organizer.css' %}">
+
     <h1>
         {% if object %}
             {% blocktranslate trimmed with provider=object.get_provider_display %}Edit {{ provider }} Account{% endblocktranslate %}
@@ -45,18 +48,18 @@
             </form>
 
             {% if setup_instructions %}
-            <div class="well" style="margin-top: 20px; background-color: #f7f9fa; border-left: 4px solid #337ab7;">
+            <div class="well sm-setup-instructions">
                 <h4><i class="fa fa-info-circle"></i> {% trans "How to connect:" %}</h4>
-                <ol style="padding-left: 20px; margin-bottom: 0;">
+                <ol class="sm-setup-instructions-list">
                     {% for step in setup_instructions %}
-                        <li style="margin-bottom: 5px;">{{ step }}</li>
+                        <li class="sm-setup-instructions-item">{{ step }}</li>
                     {% endfor %}
                 </ol>
             </div>
             {% endif %}
 
             {% if object %}
-            <div id="test-connection-result" style="display:none; margin-top:15px;"></div>
+            <div id="test-connection-result" class="sm-test-connection-result"></div>
             {% endif %}
         </div>
     </div>

--- a/socialmedia/templates/socialmedia/organizer/accounts.html
+++ b/socialmedia/templates/socialmedia/organizer/accounts.html
@@ -1,11 +1,14 @@
 {% extends "eventyay_common/organizers/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load static %}
 
 {% block title %}{% trans "Social Media Accounts" %} :: {{ organizer.name }}{% endblock %}
 
 {% block inner %}
-    <div class="pull-right flip">
+    <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/organizer.css' %}">
+
+    <div class="pull-right flip sm-organizer-header-actions">
         {% if back_to_event_url %}
             <a href="{{ back_to_event_url }}" class="btn btn-default">
                 <i class="fa fa-arrow-left"></i> {% trans "Back to Event Social Media" %}

--- a/socialmedia/templates/socialmedia/organizer/accounts.html
+++ b/socialmedia/templates/socialmedia/organizer/accounts.html
@@ -5,8 +5,11 @@
 
 {% block title %}{% trans "Social Media Accounts" %} :: {{ organizer.name }}{% endblock %}
 
-{% block inner %}
+{% block custom_header %}
     <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/organizer.css' %}">
+{% endblock %}
+
+{% block inner %}
 
     <div class="pull-right flip sm-organizer-header-actions">
         {% if back_to_event_url %}

--- a/socialmedia/templates/socialmedia/posts.html
+++ b/socialmedia/templates/socialmedia/posts.html
@@ -5,8 +5,11 @@
 
 {% block title %}{% trans "Social Media — Posts" %} :: {{ event.name }}{% endblock %}
 
-{% block content %}
+{% block custom_header %}
 <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+{% endblock %}
+
+{% block content %}
 
 <div class="sm-page">
 
@@ -67,9 +70,9 @@
         <option value="-30">{% trans "1 month before (30 days)" %}</option>
         <option value="custom">{% trans "Custom..." %}</option>
       </select>
-      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs" style="display: none; align-items: center; gap: 4px;">
-        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm" style="width: 130px; display: inline-block;">
-        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" style="width: 100px; display: inline-block;" value="09:00">
+      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs">
+        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm">
+        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" value="09:00">
       </div>
       <button id="btn-apply-schedule" class="btn btn-default btn-sm" type="button">
         {% trans "Apply" %}

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -67,9 +67,9 @@
         <option value="-30">{% trans "1 month before (30 days)" %}</option>
         <option value="custom">{% trans "Custom..." %}</option>
       </select>
-      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs" style="display: none; align-items: center; gap: 4px;">
-        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm" style="width: 130px; display: inline-block;">
-        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" style="width: 100px; display: inline-block;" value="09:00">
+      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs">
+        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm">
+        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" value="09:00">
       </div>
       <button id="btn-apply-schedule" class="btn btn-default btn-sm" type="button">
         {% trans "Apply" %}
@@ -78,7 +78,7 @@
     <span class="sm-count" id="selected-count">–</span>
   </div>
 
-  <div id="validation-alert-container" style="display: none; margin-bottom: 12px;"></div>
+  <div id="validation-alert-container"></div>
 
   <!-- Post table -->
   <div class="sm-table-wrap">
@@ -117,8 +117,8 @@
   <!-- Export bar (below table, right-aligned) -->
   <div class="export-bar">
     <span class="selected-count" id="export-count">0 {% trans "posts selected" %}</span>
-    <div style="display: inline-flex; align-items: center; gap: 8px;">
-      <select id="export-preset-select" class="form-control input-sm" style="width: 150px; display: inline-block;">
+    <div class="sm-export-preset-wrapper">
+      <select id="export-preset-select" class="form-control input-sm">
         <option value="generic">{% trans "Generic CSV" %}</option>
         <option value="postiz">{% trans "Postiz CSV" %}</option>
         <option value="buffer">{% trans "Buffer CSV" %}</option>
@@ -141,7 +141,7 @@
     <button class="adv-header" type="button" id="adv-toggle">
       <i class="fa fa-cog"></i>
       {% trans "Advanced Settings" %}
-      <span style="font-size:12px;font-weight:400;color:#aaa;">
+      <span class="sm-preset-hint">
         — {% trans "customize templates, offsets, hashtags" %}
       </span>
       <i class="fa fa-chevron-down adv-chevron"></i>
@@ -427,7 +427,7 @@
           </div>
         </div>
 
-        <div style="padding-top: 10px; border-top: 1px solid #eee; display:flex; gap:10px;">
+        <div class="sm-preview-actions">
           <button type="submit" class="btn btn-primary">
             <i class="fa fa-save"></i> {% trans "Save Settings" %}
           </button>

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -5,8 +5,11 @@
 
 {% block title %}{% trans "Social Media" %} :: {{ event.name }}{% endblock %}
 
-{% block content %}
+{% block custom_header %}
 <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+{% endblock %}
+
+{% block content %}
 
 <div class="sm-page">
 

--- a/socialmedia/templates/socialmedia/settings_form.html
+++ b/socialmedia/templates/socialmedia/settings_form.html
@@ -5,8 +5,11 @@
 
 {% block title %}{% trans "Social Media — Settings" %} :: {{ event.name }}{% endblock %}
 
-{% block content %}
+{% block custom_header %}
 <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
+{% endblock %}
+
+{% block content %}
 
 <div class="sm-page">
   <div class="sm-toolbar">
@@ -305,8 +308,6 @@
       </button>
     </div>
   </form>
-
 </div><!-- /sm-page -->
-<link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
 <script src="{% static 'socialmedia/js/settings.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Fixes fossasia/eventyay#4908

#### **Summary of Changes**
- **Organizer Back Button Alignment**: Added top margin to the `.sm-organizer-header-actions` button wrapper in `accounts.html` so the "Back to Events" / "Back to Event Social Media" button has proper clearance and no longer overlaps with the top navigation bar.
<img width="549" height="222" alt="260813_18h45m40s_screenshot" src="https://github.com/user-attachments/assets/4a76683d-2a5c-407f-8968-b4d4c740e1b8" />

- **Removed All Inline CSS**: Cleaned up all inline `style="..."` attributes across plugin templates and extracted styles into dedicated modular CSS files:
  - Created [`organizer.css`](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/static/socialmedia/css/organizer.css) for organizer settings views.
  - Created [`dashboard.css`](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/static/socialmedia/css/dashboard.css) for the plugin landing dashboard.
  - Extended [`settings.css`](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/static/socialmedia/css/settings.css) with utility classes for form controls, validation alerts, and action footers.

## Summary by Sourcery

Improve social media plugin layout consistency by fixing organizer navigation spacing and moving presentation styles into maintainable CSS files.

Bug Fixes:
- Fix organizer account navigation buttons overlapping the top navigation by adding appropriate spacing.

Enhancements:
- Replace inline template styling with reusable, page-specific CSS classes for the dashboard and organizer views, while consolidating shared settings styles.
- Load page styles through dedicated template header blocks across the social media views.