### PR TITLE
feat: add speaker social handles support in templates and previews

### DIFF
--- a/socialmedia/crypto.py
+++ b/socialmedia/crypto.py
@@ -1,9 +1,12 @@
 import base64
 import hashlib
 import json
+import logging
 
 from cryptography.fernet import Fernet
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 def _get_fernet() -> Fernet:
@@ -31,6 +34,6 @@ def decrypt_credentials(encrypted_text: str) -> dict:
         fernet = _get_fernet()
         decrypted_bytes = fernet.decrypt(encrypted_text.encode("utf-8"))
         return json.loads(decrypted_bytes.decode("utf-8"))
-    except Exception:
-        # Return empty dictionary in case of tampering or key mismatch
+    except Exception as exc:
+        logger.warning("Failed to decrypt credentials: %s", exc)
         return {}

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -32,30 +32,30 @@ DEFAULT_TEMPLATES = {
     },
     "speaker": {
         "announcement": (
-            "🎤 Meet our speaker {speaker_name} ({speaker_social_handle}) at {event_name}! "
+            "🎤 Meet our speaker {speaker_name} {speaker_social_handle} at {event_name}! "
             "They'll be presenting '{talk_title}'. "
             "Learn more: {speaker_link} {hashtags}"
         ),
         "reminder": (
-            "🗓 Don't miss {speaker_name} ({speaker_social_handle}) speaking on '{talk_title}' "
+            "🗓 Don't miss {speaker_name} {speaker_social_handle} speaking on '{talk_title}' "
             "at {event_name}! Check session details: {speaker_link} {hashtags}"
         ),
         "final_call": (
-            "🔥 Spotlight on {speaker_name} ({speaker_social_handle}) presenting '{talk_title}' at "
+            "🔥 Spotlight on {speaker_name} {speaker_social_handle} presenting '{talk_title}' at "
             "{event_name}! Catch them live: {speaker_link} {hashtags}"
         ),
     },
     "session": {
         "announcement": (
-            "🗓 Coming up at {event_name}: '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
+            "🗓 Coming up at {event_name}: '{talk_title}' by {speaker_names} {speaker_social_handles} "
             "in {talk_room} at {talk_start_time}. Don't miss it! {talk_link} {hashtags}"
         ),
         "reminder": (
-            "⏰ Session starting soon! '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
+            "⏰ Session starting soon! '{talk_title}' by {speaker_names} {speaker_social_handles} "
             "begins at {talk_start_time} in {talk_room}. {talk_link} {hashtags}"
         ),
         "final_call": (
-            "🔥 Starting now! '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
+            "🔥 Starting now! '{talk_title}' by {speaker_names} {speaker_social_handles} "
             "in {talk_room}. Join live: {talk_link} {hashtags}"
         ),
     },
@@ -119,25 +119,25 @@ PLATFORM_DEFAULT_TEMPLATES = {
         },
         "speaker": {
             "announcement": (
-                "🎤 Meet our speaker {speaker_name} ({speaker_social_handle}) at {event_name}! "
+                "🎤 Meet our speaker {speaker_name} {speaker_social_handle} at {event_name}! "
                 "'{talk_title}' {speaker_link} {hashtags}"
             ),
             "reminder": (
-                "🗓 Don't miss {speaker_name} ({speaker_social_handle}) on '{talk_title}' at {event_name}! "
+                "🗓 Don't miss {speaker_name} {speaker_social_handle} on '{talk_title}' at {event_name}! "
                 "{speaker_link} {hashtags}"
             ),
             "final_call": (
-                "🔥 {speaker_name} ({speaker_social_handle}) presenting '{talk_title}' at {event_name}. "
+                "🔥 {speaker_name} {speaker_social_handle} presenting '{talk_title}' at {event_name}. "
                 "Live soon! {speaker_link} {hashtags}"
             ),
         },
         "session": {
             "announcement": (
-                "🗓 Coming up: '{talk_title}' by {speaker_names} ({speaker_social_handles}) at {event_name}. "
+                "🗓 Coming up: '{talk_title}' by {speaker_names} {speaker_social_handles} at {event_name}. "
                 "{talk_link} {hashtags}"
             ),
             "reminder": (
-                "⏰ Starting soon: '{talk_title}' by {speaker_names} ({speaker_social_handles}) at {talk_start_time}. "
+                "⏰ Starting soon: '{talk_title}' by {speaker_names} {speaker_social_handles} at {talk_start_time}. "
                 "{talk_link} {hashtags}"
             ),
             "final_call": (
@@ -185,16 +185,16 @@ PLATFORM_DEFAULT_TEMPLATES = {
         "speaker": {
             "announcement": (
                 "🎤 Speaker announcement for {event_name}!\n"
-                "{speaker_name} ({speaker_social_handle}) will present '{talk_title}'.\n"
+                "{speaker_name} {speaker_social_handle} will present '{talk_title}'.\n"
                 "Learn more: {speaker_link}\n{hashtags}"
             ),
             "reminder": (
-                "🗓 Reminder: {speaker_name} ({speaker_social_handle}) is presenting '{talk_title}' "
+                "🗓 Reminder: {speaker_name} {speaker_social_handle} is presenting '{talk_title}' "
                 "at {event_name}!\n"
                 "Details: {speaker_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 Starting soon! Catch {speaker_name} ({speaker_social_handle}) presenting "
+                "🔥 Starting soon! Catch {speaker_name} {speaker_social_handle} presenting "
                 "'{talk_title}' at {event_name}.\n"
                 "{speaker_link}\n{hashtags}"
             ),
@@ -202,17 +202,17 @@ PLATFORM_DEFAULT_TEMPLATES = {
         "session": {
             "announcement": (
                 "🗓 Upcoming session at {event_name}:\n"
-                "'{talk_title}' by {speaker_names} ({speaker_social_handles})\n"
+                "'{talk_title}' by {speaker_names} {speaker_social_handles}\n"
                 "Room: {talk_room} | Time: {talk_start_time}\n"
                 "Full info: {talk_link}\n{hashtags}"
             ),
             "reminder": (
                 "⏰ Session starting soon at {event_name}:\n"
-                "'{talk_title}' by {speaker_names} ({speaker_social_handles}) at {talk_start_time}\n"
+                "'{talk_title}' by {speaker_names} {speaker_social_handles} at {talk_start_time}\n"
                 "{talk_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 Starting now! '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
+                "🔥 Starting now! '{talk_title}' by {speaker_names} {speaker_social_handles} "
                 "in {talk_room}.\n"
                 "Join: {talk_link}\n{hashtags}"
             ),
@@ -262,33 +262,33 @@ PLATFORM_DEFAULT_TEMPLATES = {
         "speaker": {
             "announcement": (
                 "🎤 *Speaker Spotlight* — {event_name}\n"
-                "*{speaker_name}* ({speaker_social_handle}) will present *'{talk_title}'*\n"
+                "*{speaker_name}* {speaker_social_handle} will present *'{talk_title}'*\n"
                 "More info: {speaker_link}\n{hashtags}"
             ),
             "reminder": (
-                "🗓 *Don't miss* {speaker_name} ({speaker_social_handle}) presenting "
+                "🗓 *Don't miss* {speaker_name} {speaker_social_handle} presenting "
                 "*'{talk_title}'* at {event_name}!\n"
                 "{speaker_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 *Live soon!* {speaker_name} ({speaker_social_handle}) — *'{talk_title}'* at {event_name}\n"
+                "🔥 *Live soon!* {speaker_name} {speaker_social_handle} — *'{talk_title}'* at {event_name}\n"
                 "{speaker_link}\n{hashtags}"
             ),
         },
         "session": {
             "announcement": (
                 "🗓 *Upcoming Session* — {event_name}\n"
-                "*'{talk_title}'* by {speaker_names} ({speaker_social_handles})\n"
+                "*'{talk_title}'* by {speaker_names} {speaker_social_handles}\n"
                 "Room: {talk_room} | Time: {talk_start_time}\n"
                 "{talk_link}\n{hashtags}"
             ),
             "reminder": (
                 "⏰ *Session Starting Soon* — {event_name}\n"
-                "*'{talk_title}'* by {speaker_names} ({speaker_social_handles}) at {talk_start_time}\n"
+                "*'{talk_title}'* by {speaker_names} {speaker_social_handles} at {talk_start_time}\n"
                 "{talk_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 *Starting Now!* *'{talk_title}'* by {speaker_names} ({speaker_social_handles}) "
+                "🔥 *Starting Now!* *'{talk_title}'* by {speaker_names} {speaker_social_handles} "
                 "in {talk_room}\n"
                 "Join: {talk_link}\n{hashtags}"
             ),
@@ -339,29 +339,29 @@ PLATFORM_DEFAULT_TEMPLATES = {
         },
         "speaker": {
             "announcement": (
-                "We're thrilled to feature {speaker_name} ({speaker_social_handle}) at {event_name}! "
+                "We're thrilled to feature {speaker_name} {speaker_social_handle} at {event_name}! "
                 "Join us for their talk: '{talk_title}'. "
                 "Learn more about this session: {speaker_link} {hashtags}"
             ),
             "reminder": (
-                "Don't miss {speaker_name} ({speaker_social_handle}) presenting '{talk_title}' at {event_name}. "
+                "Don't miss {speaker_name} {speaker_social_handle} presenting '{talk_title}' at {event_name}. "
                 "A session not to be missed! Details: {speaker_link} {hashtags}"
             ),
             "final_call": (
-                "Spotlight: {speaker_name} ({speaker_social_handle}) will be presenting '{talk_title}' "
+                "Spotlight: {speaker_name} {speaker_social_handle} will be presenting '{talk_title}' "
                 "at {event_name}. "
                 "Join us live! {speaker_link} {hashtags}"
             ),
         },
         "session": {
             "announcement": (
-                "Mark your calendars! '{talk_title}' by {speaker_names} ({speaker_social_handles}) is "
+                "Mark your calendars! '{talk_title}' by {speaker_names} {speaker_social_handles} is "
                 "coming up at {event_name}. "
                 "Room: {talk_room} | Time: {talk_start_time}. "
                 "Full details: {talk_link} {hashtags}"
             ),
             "reminder": (
-                "Session starting soon: '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
+                "Session starting soon: '{talk_title}' by {speaker_names} {speaker_social_handles} "
                 "at {talk_start_time} in {talk_room} during {event_name}. "
                 "Don't miss it: {talk_link} {hashtags}"
             ),
@@ -475,6 +475,7 @@ def _extract_speaker_social_info(speaker, event=None, target_platform=None):
         "speaker_twitter": "",
         "speaker_x": "",
         "speaker_linkedin": "",
+        "speaker_linkedin_url": "",
         "speaker_github": "",
         "speaker_mastodon": "",
         "speaker_telegram": "",
@@ -530,7 +531,7 @@ def _extract_speaker_social_info(speaker, event=None, target_platform=None):
                 path = path[1:]
 
         handle = path
-        if net in ("twitter", "x", "mastodon", "telegram", "instagram") and handle:
+        if net in ("twitter", "x", "github", "linkedin", "mastodon", "telegram", "instagram") and handle:
             if not handle.startswith("@"):
                 handle = f"@{handle}"
 
@@ -548,7 +549,8 @@ def _extract_speaker_social_info(speaker, event=None, target_platform=None):
         social_info["speaker_twitter"] = tw["handle"]
         social_info["speaker_x"] = tw["handle"]
     if "linkedin" in by_network:
-        social_info["speaker_linkedin"] = by_network["linkedin"]["url"]
+        social_info["speaker_linkedin"] = by_network["linkedin"]["handle"]
+        social_info["speaker_linkedin_url"] = by_network["linkedin"]["url"]
     if "github" in by_network:
         social_info["speaker_github"] = by_network["github"]["handle"]
     if "mastodon" in by_network:
@@ -563,21 +565,29 @@ def _extract_speaker_social_info(speaker, event=None, target_platform=None):
     primary_link = ""
     primary_handle = ""
 
-    if target_platform and target_platform.lower() in by_network:
-        target_info = by_network[target_platform.lower()]
-        primary_link = target_info["url"]
-        primary_handle = target_info["handle"]
-    elif "twitter" in by_network or "x" in by_network:
-        tw = by_network.get("twitter") or by_network.get("x")
-        primary_link = tw["url"]
-        primary_handle = tw["handle"]
-    elif "mastodon" in by_network:
-        primary_link = by_network["mastodon"]["url"]
-        primary_handle = by_network["mastodon"]["handle"]
-    elif serialized_links:
-        first = serialized_links[0]
-        primary_link = first["url"]
-        primary_handle = first["handle"]
+    if target_platform:
+        tgt = target_platform.lower()
+        if tgt in ("twitter", "x"):
+            tw = by_network.get("twitter") or by_network.get("x")
+            if tw:
+                primary_link = tw["url"]
+                primary_handle = tw["handle"]
+        elif tgt in by_network:
+            info_tgt = by_network[tgt]
+            primary_link = info_tgt["url"]
+            primary_handle = info_tgt["handle"]
+    else:
+        if "twitter" in by_network or "x" in by_network:
+            tw = by_network.get("twitter") or by_network.get("x")
+            primary_link = tw["url"]
+            primary_handle = tw["handle"]
+        elif "mastodon" in by_network:
+            primary_link = by_network["mastodon"]["url"]
+            primary_handle = by_network["mastodon"]["handle"]
+        elif serialized_links:
+            first = serialized_links[0]
+            primary_link = first["url"]
+            primary_handle = first["handle"]
 
     social_info["speaker_social_handle"] = primary_handle
     social_info["speaker_social_link"] = primary_link
@@ -586,7 +596,10 @@ def _extract_speaker_social_info(speaker, event=None, target_platform=None):
 
 
 def safe_format(template, **kwargs):
-    """Replace {placeholders} in template; leave unknown ones as literal text."""
+    """Replace {placeholders} in template; leave unknown ones as literal text.
+    Strips empty parentheses (), brackets [], braces {}, or angle brackets <>
+    left behind when optional placeholders resolve to empty strings.
+    """
 
     def replace(match):
         key = match.group(1)
@@ -596,7 +609,7 @@ def safe_format(template, **kwargs):
         return "{" + key + "}"
 
     res = re.sub(r"\{([a-zA-Z0-9_]+)\}", replace, template)
-    res = re.sub(r"\s*\(\s*\)", "", res)
+    res = re.sub(r"\s*[\(\[\{<]\s*[\)\]\}>]", "", res)
     res = re.sub(r"  +", " ", res)
     return res.strip()
 
@@ -1043,16 +1056,6 @@ def build_posts(event, request=None):
                     sub_speakers = list(sub.speakers.all())
                     names = ", ".join(s.get_display_name() for s in sub_speakers)
 
-                    sess_social_links = []
-                    sess_handles = []
-                    for spk in sub_speakers:
-                        s_info, s_links = _extract_speaker_social_info(spk, event=event)
-                        if s_info.get("speaker_social_handle"):
-                            sess_handles.append(s_info["speaker_social_handle"])
-                        sess_social_links.extend(s_links)
-
-                    speaker_handles_str = ", ".join(sess_handles)
-
                     room = talk.room.name if (talk and talk.room) else "TBA"
                     if sub.code:
                         talk_url = event_absolute_url(
@@ -1075,6 +1078,18 @@ def build_posts(event, request=None):
                         base_id = f"session_{talk_pk}"
                         platform_iter = enabled_platforms if use_platforms else [None]
                         for platform in platform_iter:
+                            sess_social_links = []
+                            sess_handles = []
+                            for spk in sub_speakers:
+                                s_info, s_links = _extract_speaker_social_info(
+                                    spk, event=event, target_platform=platform
+                                )
+                                if s_info.get("speaker_social_handle"):
+                                    sess_handles.append(s_info["speaker_social_handle"])
+                                sess_social_links.extend(s_links)
+
+                            speaker_handles_str = ", ".join(sess_handles)
+
                             if platform:
                                 text_formatted = _get_platform_template(
                                     event, "session", platform, template_ctx

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -32,30 +32,30 @@ DEFAULT_TEMPLATES = {
     },
     "speaker": {
         "announcement": (
-            "🎤 Meet our speaker {speaker_name} at {event_name}! "
+            "🎤 Meet our speaker {speaker_name} ({speaker_social_handle}) at {event_name}! "
             "They'll be presenting '{talk_title}'. "
             "Learn more: {speaker_link} {hashtags}"
         ),
         "reminder": (
-            "🗓 Don't miss {speaker_name} speaking on '{talk_title}' "
+            "🗓 Don't miss {speaker_name} ({speaker_social_handle}) speaking on '{talk_title}' "
             "at {event_name}! Check session details: {speaker_link} {hashtags}"
         ),
         "final_call": (
-            "🔥 Spotlight on {speaker_name} presenting '{talk_title}' at "
+            "🔥 Spotlight on {speaker_name} ({speaker_social_handle}) presenting '{talk_title}' at "
             "{event_name}! Catch them live: {speaker_link} {hashtags}"
         ),
     },
     "session": {
         "announcement": (
-            "🗓 Coming up at {event_name}: '{talk_title}' by {speaker_names} "
+            "🗓 Coming up at {event_name}: '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
             "in {talk_room} at {talk_start_time}. Don't miss it! {talk_link} {hashtags}"
         ),
         "reminder": (
-            "⏰ Session starting soon! '{talk_title}' by {speaker_names} "
+            "⏰ Session starting soon! '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
             "begins at {talk_start_time} in {talk_room}. {talk_link} {hashtags}"
         ),
         "final_call": (
-            "🔥 Starting now! '{talk_title}' by {speaker_names} "
+            "🔥 Starting now! '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
             "in {talk_room}. Join live: {talk_link} {hashtags}"
         ),
     },
@@ -119,25 +119,25 @@ PLATFORM_DEFAULT_TEMPLATES = {
         },
         "speaker": {
             "announcement": (
-                "🎤 Meet our speaker {speaker_name} at {event_name}! "
+                "🎤 Meet our speaker {speaker_name} ({speaker_social_handle}) at {event_name}! "
                 "'{talk_title}' {speaker_link} {hashtags}"
             ),
             "reminder": (
-                "🗓 Don't miss {speaker_name} on '{talk_title}' at {event_name}! "
+                "🗓 Don't miss {speaker_name} ({speaker_social_handle}) on '{talk_title}' at {event_name}! "
                 "{speaker_link} {hashtags}"
             ),
             "final_call": (
-                "🔥 {speaker_name} presenting '{talk_title}' at {event_name}. "
+                "🔥 {speaker_name} ({speaker_social_handle}) presenting '{talk_title}' at {event_name}. "
                 "Live soon! {speaker_link} {hashtags}"
             ),
         },
         "session": {
             "announcement": (
-                "🗓 Coming up: '{talk_title}' by {speaker_names} at {event_name}. "
+                "🗓 Coming up: '{talk_title}' by {speaker_names} ({speaker_social_handles}) at {event_name}. "
                 "{talk_link} {hashtags}"
             ),
             "reminder": (
-                "⏰ Starting soon: '{talk_title}' at {talk_start_time}. "
+                "⏰ Starting soon: '{talk_title}' by {speaker_names} ({speaker_social_handles}) at {talk_start_time}. "
                 "{talk_link} {hashtags}"
             ),
             "final_call": (
@@ -185,16 +185,16 @@ PLATFORM_DEFAULT_TEMPLATES = {
         "speaker": {
             "announcement": (
                 "🎤 Speaker announcement for {event_name}!\n"
-                "{speaker_name} will present '{talk_title}'.\n"
+                "{speaker_name} ({speaker_social_handle}) will present '{talk_title}'.\n"
                 "Learn more: {speaker_link}\n{hashtags}"
             ),
             "reminder": (
-                "🗓 Reminder: {speaker_name} is presenting '{talk_title}' "
+                "🗓 Reminder: {speaker_name} ({speaker_social_handle}) is presenting '{talk_title}' "
                 "at {event_name}!\n"
                 "Details: {speaker_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 Starting soon! Catch {speaker_name} presenting "
+                "🔥 Starting soon! Catch {speaker_name} ({speaker_social_handle}) presenting "
                 "'{talk_title}' at {event_name}.\n"
                 "{speaker_link}\n{hashtags}"
             ),
@@ -202,17 +202,17 @@ PLATFORM_DEFAULT_TEMPLATES = {
         "session": {
             "announcement": (
                 "🗓 Upcoming session at {event_name}:\n"
-                "'{talk_title}' by {speaker_names}\n"
+                "'{talk_title}' by {speaker_names} ({speaker_social_handles})\n"
                 "Room: {talk_room} | Time: {talk_start_time}\n"
                 "Full info: {talk_link}\n{hashtags}"
             ),
             "reminder": (
                 "⏰ Session starting soon at {event_name}:\n"
-                "'{talk_title}' by {speaker_names} at {talk_start_time}\n"
+                "'{talk_title}' by {speaker_names} ({speaker_social_handles}) at {talk_start_time}\n"
                 "{talk_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 Starting now! '{talk_title}' by {speaker_names} "
+                "🔥 Starting now! '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
                 "in {talk_room}.\n"
                 "Join: {talk_link}\n{hashtags}"
             ),
@@ -262,33 +262,33 @@ PLATFORM_DEFAULT_TEMPLATES = {
         "speaker": {
             "announcement": (
                 "🎤 *Speaker Spotlight* — {event_name}\n"
-                "*{speaker_name}* will present *'{talk_title}'*\n"
+                "*{speaker_name}* ({speaker_social_handle}) will present *'{talk_title}'*\n"
                 "More info: {speaker_link}\n{hashtags}"
             ),
             "reminder": (
-                "🗓 *Don't miss* {speaker_name} presenting "
+                "🗓 *Don't miss* {speaker_name} ({speaker_social_handle}) presenting "
                 "*'{talk_title}'* at {event_name}!\n"
                 "{speaker_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 *Live soon!* {speaker_name} — *'{talk_title}'* at {event_name}\n"
+                "🔥 *Live soon!* {speaker_name} ({speaker_social_handle}) — *'{talk_title}'* at {event_name}\n"
                 "{speaker_link}\n{hashtags}"
             ),
         },
         "session": {
             "announcement": (
                 "🗓 *Upcoming Session* — {event_name}\n"
-                "*'{talk_title}'* by {speaker_names}\n"
+                "*'{talk_title}'* by {speaker_names} ({speaker_social_handles})\n"
                 "Room: {talk_room} | Time: {talk_start_time}\n"
                 "{talk_link}\n{hashtags}"
             ),
             "reminder": (
                 "⏰ *Session Starting Soon* — {event_name}\n"
-                "*'{talk_title}'* by {speaker_names} at {talk_start_time}\n"
+                "*'{talk_title}'* by {speaker_names} ({speaker_social_handles}) at {talk_start_time}\n"
                 "{talk_link}\n{hashtags}"
             ),
             "final_call": (
-                "🔥 *Starting Now!* *'{talk_title}'* by {speaker_names} "
+                "🔥 *Starting Now!* *'{talk_title}'* by {speaker_names} ({speaker_social_handles}) "
                 "in {talk_room}\n"
                 "Join: {talk_link}\n{hashtags}"
             ),
@@ -339,29 +339,29 @@ PLATFORM_DEFAULT_TEMPLATES = {
         },
         "speaker": {
             "announcement": (
-                "We're thrilled to feature {speaker_name} at {event_name}! "
+                "We're thrilled to feature {speaker_name} ({speaker_social_handle}) at {event_name}! "
                 "Join us for their talk: '{talk_title}'. "
                 "Learn more about this session: {speaker_link} {hashtags}"
             ),
             "reminder": (
-                "Don't miss {speaker_name} presenting '{talk_title}' at {event_name}. "
+                "Don't miss {speaker_name} ({speaker_social_handle}) presenting '{talk_title}' at {event_name}. "
                 "A session not to be missed! Details: {speaker_link} {hashtags}"
             ),
             "final_call": (
-                "Spotlight: {speaker_name} will be presenting '{talk_title}' "
+                "Spotlight: {speaker_name} ({speaker_social_handle}) will be presenting '{talk_title}' "
                 "at {event_name}. "
                 "Join us live! {speaker_link} {hashtags}"
             ),
         },
         "session": {
             "announcement": (
-                "Mark your calendars! '{talk_title}' by {speaker_names} is "
+                "Mark your calendars! '{talk_title}' by {speaker_names} ({speaker_social_handles}) is "
                 "coming up at {event_name}. "
                 "Room: {talk_room} | Time: {talk_start_time}. "
                 "Full details: {talk_link} {hashtags}"
             ),
             "reminder": (
-                "Session starting soon: '{talk_title}' by {speaker_names} "
+                "Session starting soon: '{talk_title}' by {speaker_names} ({speaker_social_handles}) "
                 "at {talk_start_time} in {talk_room} during {event_name}. "
                 "Don't miss it: {talk_link} {hashtags}"
             ),
@@ -462,14 +462,143 @@ TYPE_LABELS = {
 # ---------------------------------------------------------------------------
 
 
+def _extract_speaker_social_info(speaker, event=None, target_platform=None):
+    """
+    Extract social media handles and profile links from a speaker (User or SpeakerProfile instance).
+    Returns:
+        social_info: dict with keys for placeholders (e.g. speaker_social_handle, speaker_twitter, etc.)
+        serialized_links: list of dicts [{'network': ..., 'url': ..., 'handle': ...}]
+    """
+    social_info = {
+        "speaker_social_handle": "",
+        "speaker_social_link": "",
+        "speaker_twitter": "",
+        "speaker_x": "",
+        "speaker_linkedin": "",
+        "speaker_github": "",
+        "speaker_mastodon": "",
+        "speaker_telegram": "",
+        "speaker_instagram": "",
+        "speaker_website": "",
+    }
+    serialized_links = []
+
+    if not speaker:
+        return social_info, serialized_links
+
+    profile = None
+    if event and hasattr(speaker, "event_profile") and callable(getattr(speaker, "event_profile")):
+        try:
+            profile = speaker.event_profile(event)
+        except Exception:
+            profile = None
+
+    if not profile and hasattr(speaker, "social_links"):
+        profile = speaker
+
+    if not profile and hasattr(speaker, "profiles"):
+        try:
+            profiles = list(speaker.profiles.all())
+            if event:
+                profiles = [
+                    p for p in profiles if getattr(p, "event_id", None) == getattr(event, "pk", None)
+                ]
+            if profiles:
+                profile = profiles[0]
+        except Exception:
+            profile = None
+
+    raw_links = []
+    if profile and hasattr(profile, "social_links"):
+        try:
+            raw_links = list(profile.social_links.all())
+        except Exception:
+            raw_links = []
+
+    by_network = {}
+    for link in raw_links:
+        net = getattr(link, "network", "").lower()
+        url = getattr(link, "url", "") or ""
+        if not url:
+            continue
+
+        path = getattr(link, "path", "")
+        if not path and "/" in url:
+            cleaned_url = url.rstrip("/")
+            path = cleaned_url.split("/")[-1]
+            if path.startswith("@"):
+                path = path[1:]
+
+        handle = path
+        if net in ("twitter", "x", "mastodon", "telegram", "instagram") and handle:
+            if not handle.startswith("@"):
+                handle = f"@{handle}"
+
+        item = {
+            "network": net,
+            "url": url,
+            "handle": handle or url,
+        }
+        serialized_links.append(item)
+        if net not in by_network:
+            by_network[net] = item
+
+    if "twitter" in by_network or "x" in by_network:
+        tw = by_network.get("twitter") or by_network.get("x")
+        social_info["speaker_twitter"] = tw["handle"]
+        social_info["speaker_x"] = tw["handle"]
+    if "linkedin" in by_network:
+        social_info["speaker_linkedin"] = by_network["linkedin"]["url"]
+    if "github" in by_network:
+        social_info["speaker_github"] = by_network["github"]["handle"]
+    if "mastodon" in by_network:
+        social_info["speaker_mastodon"] = by_network["mastodon"]["handle"]
+    if "telegram" in by_network:
+        social_info["speaker_telegram"] = by_network["telegram"]["handle"]
+    if "instagram" in by_network:
+        social_info["speaker_instagram"] = by_network["instagram"]["handle"]
+    if "website" in by_network:
+        social_info["speaker_website"] = by_network["website"]["url"]
+
+    primary_link = ""
+    primary_handle = ""
+
+    if target_platform and target_platform.lower() in by_network:
+        target_info = by_network[target_platform.lower()]
+        primary_link = target_info["url"]
+        primary_handle = target_info["handle"]
+    elif "twitter" in by_network or "x" in by_network:
+        tw = by_network.get("twitter") or by_network.get("x")
+        primary_link = tw["url"]
+        primary_handle = tw["handle"]
+    elif "mastodon" in by_network:
+        primary_link = by_network["mastodon"]["url"]
+        primary_handle = by_network["mastodon"]["handle"]
+    elif serialized_links:
+        first = serialized_links[0]
+        primary_link = first["url"]
+        primary_handle = first["handle"]
+
+    social_info["speaker_social_handle"] = primary_handle
+    social_info["speaker_social_link"] = primary_link
+
+    return social_info, serialized_links
+
+
 def safe_format(template, **kwargs):
     """Replace {placeholders} in template; leave unknown ones as literal text."""
 
     def replace(match):
         key = match.group(1)
-        return str(kwargs.get(key, "{" + key + "}"))
+        if key in kwargs:
+            val = kwargs[key]
+            return str(val) if val is not None else ""
+        return "{" + key + "}"
 
-    return re.sub(r"\{([a-zA-Z0-9_]+)\}", replace, template)
+    res = re.sub(r"\{([a-zA-Z0-9_]+)\}", replace, template)
+    res = re.sub(r"\s*\(\s*\)", "", res)
+    res = re.sub(r"  +", " ", res)
+    return res.strip()
 
 
 def localize(dt, event):
@@ -510,15 +639,21 @@ def _get_template(event, key, context="announcement"):
 def _get_platform_template(event, key, platform, context="announcement"):
     """Return a platform-specific template, cascading through:
     1. Organizer-saved per-platform custom override
-    2. Baked-in platform-specific default
-    3. Existing generic default template
+    2. Organizer-saved generic custom template
+    3. Baked-in platform-specific default
+    4. Baked-in generic default template
     """
-    # 1. Check for organizer-saved platform-specific override
-    custom = event.settings.get(f"socialmedia_{platform}_{key}_template")
-    if custom:
-        return custom
+    # 1. Organizer-saved per-platform custom override
+    custom_plat = event.settings.get(f"socialmedia_{platform}_{key}_template")
+    if custom_plat:
+        return custom_plat
 
-    # 2. Baked-in platform-specific default
+    # 2. Organizer-saved generic custom template
+    custom_gen = event.settings.get(f"socialmedia_{key}_template")
+    if custom_gen:
+        return custom_gen
+
+    # 3. Baked-in platform-specific default
     plat_tpls = PLATFORM_DEFAULT_TEMPLATES.get(platform, {})
     plat_tpl = plat_tpls.get(key, {})
     if isinstance(plat_tpl, dict):
@@ -526,7 +661,7 @@ def _get_platform_template(event, key, platform, context="announcement"):
         if result:
             return result
 
-    # 3. Fall back to generic default
+    # 4. Fall back to generic default
     return _get_template(event, key, context)
 
 
@@ -775,7 +910,9 @@ def build_posts(event, request=None):
             if SubmissionStates:
                 filters["state"] = SubmissionStates.CONFIRMED
             confirmed_subs = list(
-                submissions_mgr.filter(**filters).prefetch_related("speakers")
+                submissions_mgr.filter(**filters).prefetch_related(
+                    "speakers", "speakers__profiles", "speakers__profiles__social_links"
+                )
             )
 
             schedule = getattr(event, "current_schedule", None)
@@ -841,19 +978,29 @@ def build_posts(event, request=None):
                                 enabled_platforms if use_platforms else [None]
                             )
                             for platform in platform_iter:
+                                spk_social_info, spk_social_links = (
+                                    _extract_speaker_social_info(
+                                        speaker, event=event, target_platform=platform
+                                    )
+                                )
                                 if platform:
                                     text_formatted = _get_platform_template(
                                         event, "speaker", platform, template_ctx
                                     )
                                 else:
                                     text_formatted = text
+
+                                format_kwargs = {
+                                    "event_name": str(event.name),
+                                    "speaker_name": speaker.get_display_name(),
+                                    "speaker_link": spk_url,
+                                    "talk_title": sub.title,
+                                    "hashtags": hashtags,
+                                }
+                                format_kwargs.update(spk_social_info)
+
                                 text_formatted = safe_format(
-                                    text_formatted,
-                                    event_name=str(event.name),
-                                    speaker_name=speaker.get_display_name(),
-                                    speaker_link=spk_url,
-                                    talk_title=sub.title,
-                                    hashtags=hashtags,
+                                    text_formatted, **format_kwargs
                                 )
                                 post_id = (
                                     f"{base_id}_{platform}" if platform else base_id
@@ -881,12 +1028,31 @@ def build_posts(event, request=None):
                                         "is_schedule_associated": True,
                                         "offset_days": spk_off,
                                         "template_context": template_ctx,
+                                        "speaker_social_links": spk_social_links,
+                                        "speaker_social_handle": spk_social_info.get(
+                                            "speaker_social_handle", ""
+                                        ),
+                                        "speaker_social_url": spk_social_info.get(
+                                            "speaker_social_link", ""
+                                        ),
                                     }
                                 )
 
                 # Session post
                 if session_enabled and talk_start:
-                    names = ", ".join(s.get_display_name() for s in sub.speakers.all())
+                    sub_speakers = list(sub.speakers.all())
+                    names = ", ".join(s.get_display_name() for s in sub_speakers)
+
+                    sess_social_links = []
+                    sess_handles = []
+                    for spk in sub_speakers:
+                        s_info, s_links = _extract_speaker_social_info(spk, event=event)
+                        if s_info.get("speaker_social_handle"):
+                            sess_handles.append(s_info["speaker_social_handle"])
+                        sess_social_links.extend(s_links)
+
+                    speaker_handles_str = ", ".join(sess_handles)
+
                     room = talk.room.name if (talk and talk.room) else "TBA"
                     if sub.code:
                         talk_url = event_absolute_url(
@@ -915,19 +1081,25 @@ def build_posts(event, request=None):
                                 )
                             else:
                                 text_formatted = text
-                            text_formatted = safe_format(
-                                text_formatted,
-                                event_name=str(event.name),
-                                talk_title=sub.title,
-                                talk_room=room,
-                                talk_start_time=(
+
+                            format_kwargs = {
+                                "event_name": str(event.name),
+                                "talk_title": sub.title,
+                                "talk_room": room,
+                                "talk_start_time": (
                                     localize(talk_start, event).strftime("%H:%M")
                                     if talk_start
                                     else "TBA"
                                 ),
-                                speaker_names=names,
-                                talk_link=talk_url,
-                                hashtags=hashtags,
+                                "speaker_names": names,
+                                "speaker_social_handles": speaker_handles_str,
+                                "speaker_handles": speaker_handles_str,
+                                "talk_link": talk_url,
+                                "hashtags": hashtags,
+                            }
+
+                            text_formatted = safe_format(
+                                text_formatted, **format_kwargs
                             )
                             post_id = f"{base_id}_{platform}" if platform else base_id
                             posts.append(
@@ -950,6 +1122,8 @@ def build_posts(event, request=None):
                                     "is_schedule_associated": True,
                                     "offset_days": sess_off,
                                     "template_context": template_ctx,
+                                    "speaker_social_links": sess_social_links,
+                                    "speaker_social_handles": speaker_handles_str,
                                 }
                             )
 

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -1,10 +1,13 @@
 import csv
 import io
+import logging
 import re
 from datetime import timedelta
 
 import pytz
 from django.utils.timezone import is_naive, make_aware
+
+logger = logging.getLogger(__name__)
 
 try:
     from eventyay.base.models.submission import SubmissionStates
@@ -491,7 +494,8 @@ def _extract_speaker_social_info(speaker, event=None, target_platform=None):
     if event and hasattr(speaker, "event_profile") and callable(getattr(speaker, "event_profile")):
         try:
             profile = speaker.event_profile(event)
-        except Exception:
+        except Exception as exc:
+            logger.warning("Error fetching event profile for speaker: %s", exc)
             profile = None
 
     if not profile and hasattr(speaker, "social_links"):
@@ -506,14 +510,16 @@ def _extract_speaker_social_info(speaker, event=None, target_platform=None):
                 ]
             if profiles:
                 profile = profiles[0]
-        except Exception:
+        except Exception as exc:
+            logger.warning("Error querying speaker profiles: %s", exc)
             profile = None
 
     raw_links = []
     if profile and hasattr(profile, "social_links"):
         try:
             raw_links = list(profile.social_links.all())
-        except Exception:
+        except Exception as exc:
+            logger.warning("Error fetching speaker social links: %s", exc)
             raw_links = []
 
     by_network = {}
@@ -855,7 +861,8 @@ def build_posts(event, request=None):
             active_tickets = list(
                 event.products.filter(active=True, category__is_addon=False)[:5]
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Error querying active tickets: %s", exc)
             active_tickets = []
         for ticket in active_tickets:
             price_str = (
@@ -1163,7 +1170,8 @@ def sync_posts_to_db(event, request=None):
         try:
             naive_dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
             scheduled_at = tz.localize(naive_dt)
-        except Exception:
+        except Exception as exc:
+            logger.warning("Error parsing datetime string '%s': %s", dt_str, exc)
             continue
 
         offset_val = p.get("offset_days", 0)

--- a/socialmedia/providers/telegram.py
+++ b/socialmedia/providers/telegram.py
@@ -72,7 +72,8 @@ class TelegramProvider(BaseSocialProvider):
             try:
                 err_data = response.json()
                 desc = err_data.get("description", response.text)
-            except Exception:
+            except Exception as exc:
+                logger.debug("Failed to parse Telegram error response body: %s", exc)
                 desc = response.text
 
             return {
@@ -110,8 +111,8 @@ class TelegramProvider(BaseSocialProvider):
                     username = result.get("username") or "unknown"
                     first_name = result.get("first_name") or "Telegram bot"
                     return f"@{username} ({first_name})"
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Failed to fetch Telegram bot info: %s", exc)
         return "Unknown Bot"
 
     def _error_hint(self, description: str) -> str:

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -1166,7 +1166,7 @@ body .sm-toast i {
 
 /* Bulk schedule & export helpers */
 #bulk-schedule-custom-inputs {
-  display: none;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
 }

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -1163,3 +1163,54 @@ body .sm-toast i {
   font-size: 12px;
   color: #6c757d;
 }
+
+/* Bulk schedule & export helpers */
+#bulk-schedule-custom-inputs {
+  display: none;
+  align-items: center;
+  gap: 4px;
+}
+
+#bulk-schedule-custom-date {
+  width: 130px;
+  display: inline-block;
+}
+
+#bulk-schedule-custom-time {
+  width: 100px;
+  display: inline-block;
+}
+
+#validation-alert-container {
+  display: none;
+  margin-bottom: 12px;
+}
+
+.sm-export-preset-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#export-preset-select {
+  width: 150px;
+  display: inline-block;
+}
+
+.sm-preset-hint {
+  font-size: 12px;
+  font-weight: 400;
+  color: #aaa;
+}
+
+.sm-preview-actions {
+  padding-top: 10px;
+  border-top: 1px solid #eee;
+  display: flex;
+  gap: 10px;
+}
+
+.sm-placeholder-help {
+  font-size: 11px;
+  margin-top: 5px;
+}

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -1214,3 +1214,51 @@ body .sm-toast i {
   font-size: 11px;
   margin-top: 5px;
 }
+
+/* Speaker social links in table and preview modal */
+.speaker-social-links-row {
+  margin-top: 4px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.speaker-social-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  color: #337ab7;
+  text-decoration: none;
+}
+
+.speaker-social-pill:hover {
+  text-decoration: underline;
+}
+
+.sm-preview-speaker-socials {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-top: 1px solid #eee;
+  background: #f9f9f9;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sm-speaker-social-label {
+  font-size: 11px;
+  color: #666;
+  font-weight: 600;
+}
+
+.sm-speaker-social-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 12px;
+  font-size: 11px;
+}

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -17,7 +17,7 @@
       UPDATE_URL: config.updateUrl || "",
       SYNC_URL: config.syncUrl || "",
       PUBLISH_NOW_URL: config.publishNowUrl || (config.updateUrl ? config.updateUrl.replace(/\/update\/?$/, "/publish-now/") : null),
-      CSRF_TOKEN: config.csrfToken || "",
+      CSRF_TOKEN: config.csrfToken || (document.querySelector("input[name=csrfmiddlewaretoken]") ? document.querySelector("input[name=csrfmiddlewaretoken]").value : ""),
       TRANS_CLICK_TO_EDIT: config.transClickToEdit || "Click to edit · Ctrl+Enter to save",
       TRANS_SELECT_AT_LEAST_ONE: config.transSelectAtLeastOne || "Please select at least one post to export.",
     };

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -644,7 +644,6 @@
       if (p.speaker_social_links && p.speaker_social_links.length > 0) {
         const linksDiv = document.createElement("div");
         linksDiv.className = "speaker-social-links-row";
-        linksDiv.style.cssText = "margin-top: 4px; display: flex; gap: 6px; flex-wrap: wrap; align-items: center;";
 
         p.speaker_social_links.forEach((link) => {
           if (!link.url) return;
@@ -653,7 +652,6 @@
           a.target = "_blank";
           a.rel = "noopener noreferrer";
           a.className = "speaker-social-pill";
-          a.style.cssText = "display: inline-flex; align-items: center; gap: 3px; font-size: 11px; color: #337ab7; text-decoration: none;";
 
           const icon = document.createElement("i");
           const net = (link.network || "globe").toLowerCase();
@@ -829,11 +827,9 @@
       if (post.speaker_social_links && post.speaker_social_links.length > 0) {
         const socialBox = document.createElement("div");
         socialBox.className = "sm-preview-speaker-socials";
-        socialBox.style.cssText = "margin-top: 10px; padding: 8px 12px; border-top: 1px solid #eee; background: #f9f9f9; border-radius: 4px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;";
 
         const label = document.createElement("span");
         label.className = "sm-speaker-social-label";
-        label.style.cssText = "font-size: 11px; color: #666; font-weight: 600;";
         label.textContent = "Speaker Profiles:";
         socialBox.appendChild(label);
 
@@ -844,7 +840,6 @@
           a.target = "_blank";
           a.rel = "noopener noreferrer";
           a.className = "sm-speaker-social-link btn btn-xs btn-default";
-          a.style.cssText = "display: inline-flex; align-items: center; gap: 4px; border-radius: 12px; font-size: 11px;";
 
           const icon = document.createElement("i");
           const net = (link.network || "globe").toLowerCase();

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -2,22 +2,24 @@
   // ---- Config module ----
   const Config = (function () {
     const configEl = document.getElementById("socialmedia-config");
-    if (!configEl) return null;
-    const config = JSON.parse(configEl.textContent);
+    let config = {};
+    if (configEl && configEl.textContent) {
+      try {
+        config = JSON.parse(configEl.textContent);
+      } catch (e) {}
+    }
 
     return {
-      PREVIEW_URL: config.previewUrl,
-      EXPORT_URL: config.exportUrl,
-      UPDATE_URL: config.updateUrl,
-      SYNC_URL: config.syncUrl,
+      PREVIEW_URL: config.previewUrl || "",
+      EXPORT_URL: config.exportUrl || "",
+      UPDATE_URL: config.updateUrl || "",
+      SYNC_URL: config.syncUrl || "",
       PUBLISH_NOW_URL: config.publishNowUrl || (config.updateUrl ? config.updateUrl.replace(/\/update\/?$/, "/publish-now/") : null),
-      CSRF_TOKEN: config.csrfToken,
+      CSRF_TOKEN: config.csrfToken || "",
       TRANS_CLICK_TO_EDIT: config.transClickToEdit || "Click to edit · Ctrl+Enter to save",
       TRANS_SELECT_AT_LEAST_ONE: config.transSelectAtLeastOne || "Please select at least one post to export.",
     };
   })();
-
-  if (!Config) return;
 
   // ---- Platform metadata ----
   const PLATFORM_META = {
@@ -637,6 +639,36 @@
         tdContent.appendChild(warn);
       }
 
+      if (p.speaker_social_links && p.speaker_social_links.length > 0) {
+        const linksDiv = document.createElement("div");
+        linksDiv.className = "speaker-social-links-row";
+        linksDiv.style.cssText = "margin-top: 4px; display: flex; gap: 6px; flex-wrap: wrap; align-items: center;";
+
+        p.speaker_social_links.forEach((link) => {
+          if (!link.url) return;
+          const a = document.createElement("a");
+          a.href = link.url;
+          a.target = "_blank";
+          a.rel = "noopener noreferrer";
+          a.className = "speaker-social-pill";
+          a.style.cssText = "display: inline-flex; align-items: center; gap: 3px; font-size: 11px; color: #337ab7; text-decoration: none;";
+
+          const icon = document.createElement("i");
+          const net = (link.network || "globe").toLowerCase();
+          if (net === "twitter" || net === "x") icon.className = "fa fa-twitter";
+          else if (net === "linkedin") icon.className = "fa fa-linkedin";
+          else if (net === "github") icon.className = "fa fa-github";
+          else if (net === "telegram") icon.className = "fa fa-telegram";
+          else if (net === "instagram") icon.className = "fa fa-instagram";
+          else icon.className = "fa fa-globe";
+
+          a.appendChild(icon);
+          a.appendChild(document.createTextNode(link.handle || link.network));
+          linksDiv.appendChild(a);
+        });
+        tdContent.appendChild(linksDiv);
+      }
+
       tdContent.appendChild(editArea);
       tr.appendChild(tdContent);
 
@@ -789,6 +821,44 @@
         mediaImg.alt = "Post Media Attachment";
         mediaBox.appendChild(mediaImg);
         previewBox.appendChild(mediaBox);
+      }
+
+      // Speaker Social Links Section (if present)
+      if (post.speaker_social_links && post.speaker_social_links.length > 0) {
+        const socialBox = document.createElement("div");
+        socialBox.className = "sm-preview-speaker-socials";
+        socialBox.style.cssText = "margin-top: 10px; padding: 8px 12px; border-top: 1px solid #eee; background: #f9f9f9; border-radius: 4px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;";
+
+        const label = document.createElement("span");
+        label.className = "sm-speaker-social-label";
+        label.style.cssText = "font-size: 11px; color: #666; font-weight: 600;";
+        label.textContent = "Speaker Profiles:";
+        socialBox.appendChild(label);
+
+        post.speaker_social_links.forEach((link) => {
+          if (!link.url) return;
+          const a = document.createElement("a");
+          a.href = link.url;
+          a.target = "_blank";
+          a.rel = "noopener noreferrer";
+          a.className = "sm-speaker-social-link btn btn-xs btn-default";
+          a.style.cssText = "display: inline-flex; align-items: center; gap: 4px; border-radius: 12px; font-size: 11px;";
+
+          const icon = document.createElement("i");
+          const net = (link.network || "globe").toLowerCase();
+          if (net === "twitter" || net === "x") icon.className = "fa fa-twitter";
+          else if (net === "linkedin") icon.className = "fa fa-linkedin";
+          else if (net === "github") icon.className = "fa fa-github";
+          else if (net === "telegram") icon.className = "fa fa-telegram";
+          else if (net === "instagram") icon.className = "fa fa-instagram";
+          else icon.className = "fa fa-globe";
+
+          a.appendChild(icon);
+          a.appendChild(document.createTextNode(link.handle || link.network));
+          socialBox.appendChild(a);
+        });
+
+        previewBox.appendChild(socialBox);
       }
 
       // Footer / Char Counter
@@ -1500,27 +1570,48 @@
     }
   };
 
+  // Track last focused input for token chip insertion
+  let lastFocusedInput = null;
+  document.addEventListener("focusin", (e) => {
+    if (e.target && (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA")) {
+      lastFocusedInput = e.target;
+    }
+  });
+
   // ---- Token & Preset UI Helpers ----
   function insertToken(chip) {
     const targetId = chip.dataset.target;
     const token = chip.textContent;
-    const input = document.getElementById(targetId);
+    let input = lastFocusedInput;
+    if (!input || !document.body.contains(input)) {
+      input = targetId ? document.getElementById(targetId) : null;
+    }
+    if (!input && targetId) {
+      input = document.getElementById(targetId);
+    }
     if (!input) return;
 
-    const startPos = input.selectionStart;
-    const endPos = input.selectionEnd;
-    const value = input.value;
+    const value = input.value || "";
+    let startPos = typeof input.selectionStart === "number" ? input.selectionStart : value.length;
+    let endPos = typeof input.selectionEnd === "number" ? input.selectionEnd : value.length;
+    if (startPos < 0) startPos = value.length;
+    if (endPos < 0) endPos = value.length;
 
     input.value = value.substring(0, startPos) + token + value.substring(endPos);
 
     input.focus();
-    input.selectionStart = startPos + token.length;
-    input.selectionEnd = startPos + token.length;
+    try {
+      input.selectionStart = startPos + token.length;
+      input.selectionEnd = startPos + token.length;
+    } catch (err) {}
 
-    // Trigger input/change event
-    const evt = document.createEvent("HTMLEvents");
-    evt.initEvent("input", true, true);
-    input.dispatchEvent(evt);
+    const evtInput = document.createEvent("HTMLEvents");
+    evtInput.initEvent("input", true, true);
+    input.dispatchEvent(evtInput);
+
+    const evtChange = document.createEvent("HTMLEvents");
+    evtChange.initEvent("change", true, true);
+    input.dispatchEvent(evtChange);
   }
 
   function handlePresetClick(btn) {
@@ -1547,10 +1638,30 @@
     offsets.sort((a, b) => b - a);
     input.value = offsets.join(", ");
 
-    const evt = document.createEvent("HTMLEvents");
-    evt.initEvent("change", true, true);
-    input.dispatchEvent(evt);
+    const evtInput = document.createEvent("HTMLEvents");
+    evtInput.initEvent("input", true, true);
+    input.dispatchEvent(evtInput);
+
+    const evtChange = document.createEvent("HTMLEvents");
+    evtChange.initEvent("change", true, true);
+    input.dispatchEvent(evtChange);
   }
+
+  // Document-level event delegation for token chips & preset buttons
+  document.addEventListener("click", (e) => {
+    const chip = e.target.closest(".token-chip");
+    if (chip) {
+      e.preventDefault();
+      insertToken(chip);
+      return;
+    }
+    const presetBtn = e.target.closest(".presets-container .preset-btn");
+    if (presetBtn) {
+      e.preventDefault();
+      handlePresetClick(presetBtn);
+      return;
+    }
+  });
 
   function updatePresetsUI(container, currentOffsets) {
     container.querySelectorAll(".preset-btn").forEach(btn => {

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -6,7 +6,9 @@
     if (configEl && configEl.textContent) {
       try {
         config = JSON.parse(configEl.textContent);
-      } catch (e) {}
+      } catch (e) {
+        console.warn("Failed to parse socialmedia-config JSON:", e);
+      }
     }
 
     return {
@@ -1603,7 +1605,11 @@
     try {
       input.selectionStart = startPos + token.length;
       input.selectionEnd = startPos + token.length;
-    } catch (err) {}
+    } catch (err) {
+      if (!(err instanceof DOMException)) {
+        console.warn("Failed to set input selection position:", err);
+      }
+    }
 
     const evtInput = document.createEvent("HTMLEvents");
     evtInput.initEvent("input", true, true);

--- a/socialmedia/templates/socialmedia/posts.html
+++ b/socialmedia/templates/socialmedia/posts.html
@@ -67,9 +67,9 @@
         <option value="-30">{% trans "1 month before (30 days)" %}</option>
         <option value="custom">{% trans "Custom..." %}</option>
       </select>
-      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs" style="display: none; align-items: center; gap: 4px;">
-        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm" style="width: 130px; display: inline-block;">
-        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" style="width: 100px; display: inline-block;" value="09:00">
+      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs hidden">
+        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm">
+        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" value="09:00">
       </div>
       <button id="btn-apply-schedule" class="btn btn-default btn-sm" type="button">
         {% trans "Apply" %}

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -300,10 +300,14 @@
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_social_handle}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_twitter}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_linkedin}</span>
+                <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_github}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_link}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{talk_title}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{hashtags}</span>
               </div>
+              <p class="help-block text-muted" style="font-size: 11px; margin-top: 5px;">
+                {% trans "Note: Handle placeholders output as @username across supported networks. Wrap optional placeholders in parentheses () or brackets [] to automatically omit them when empty." %}
+              </p>
             </div>
           </div>
         </div>

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -67,9 +67,9 @@
         <option value="-30">{% trans "1 month before (30 days)" %}</option>
         <option value="custom">{% trans "Custom..." %}</option>
       </select>
-      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs" style="display: none; align-items: center; gap: 4px;">
-        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm" style="width: 130px; display: inline-block;">
-        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" style="width: 100px; display: inline-block;" value="09:00">
+      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs">
+        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm">
+        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" value="09:00">
       </div>
       <button id="btn-apply-schedule" class="btn btn-default btn-sm" type="button">
         {% trans "Apply" %}
@@ -78,7 +78,7 @@
     <span class="sm-count" id="selected-count">–</span>
   </div>
 
-  <div id="validation-alert-container" style="display: none; margin-bottom: 12px;"></div>
+  <div id="validation-alert-container"></div>
 
   <!-- Post table -->
   <div class="sm-table-wrap">
@@ -117,8 +117,8 @@
   <!-- Export bar (below table, right-aligned) -->
   <div class="export-bar">
     <span class="selected-count" id="export-count">0 {% trans "posts selected" %}</span>
-    <div style="display: inline-flex; align-items: center; gap: 8px;">
-      <select id="export-preset-select" class="form-control input-sm" style="width: 150px; display: inline-block;">
+    <div class="sm-export-preset-wrapper">
+      <select id="export-preset-select" class="form-control input-sm">
         <option value="generic">{% trans "Generic CSV" %}</option>
         <option value="postiz">{% trans "Postiz CSV" %}</option>
         <option value="buffer">{% trans "Buffer CSV" %}</option>
@@ -141,7 +141,7 @@
     <button class="adv-header" type="button" id="adv-toggle">
       <i class="fa fa-cog"></i>
       {% trans "Advanced Settings" %}
-      <span style="font-size:12px;font-weight:400;color:#aaa;">
+      <span class="sm-preset-hint">
         — {% trans "customize templates, offsets, hashtags" %}
       </span>
       <i class="fa fa-chevron-down adv-chevron"></i>
@@ -305,7 +305,7 @@
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{talk_title}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{hashtags}</span>
               </div>
-              <p class="help-block text-muted" style="font-size: 11px; margin-top: 5px;">
+              <p class="help-block text-muted sm-placeholder-help">
                 {% trans "Note: Handle placeholders output as @username across supported networks. Wrap optional placeholders in parentheses () or brackets [] to automatically omit them when empty." %}
               </p>
             </div>
@@ -434,7 +434,7 @@
           </div>
         </div>
 
-        <div style="padding-top: 10px; border-top: 1px solid #eee; display:flex; gap:10px;">
+        <div class="sm-preview-actions">
           <button type="submit" class="btn btn-primary">
             <i class="fa fa-save"></i> {% trans "Save Settings" %}
           </button>

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -67,7 +67,7 @@
         <option value="-30">{% trans "1 month before (30 days)" %}</option>
         <option value="custom">{% trans "Custom..." %}</option>
       </select>
-      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs">
+      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs hidden">
         <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm">
         <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" value="09:00">
       </div>

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -297,6 +297,9 @@
                 <span class="tokens-label">{% trans "Insert Placeholders:" %}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{event_name}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_name}</span>
+                <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_social_handle}</span>
+                <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_twitter}</span>
+                <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_linkedin}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_link}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{talk_title}</span>
                 <span class="token-chip" data-target="id_socialmedia_speaker_template">{hashtags}</span>

--- a/socialmedia/templates/socialmedia/settings_form.html
+++ b/socialmedia/templates/socialmedia/settings_form.html
@@ -169,10 +169,14 @@
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_social_handle}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_twitter}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_linkedin}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_github}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_link}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{talk_title}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{hashtags}</span>
           </div>
+          <p class="help-block text-muted" style="font-size: 11px; margin-top: 5px;">
+            {% trans "Note: Handle placeholders output as @username across supported networks. Wrap optional placeholders in parentheses () or brackets [] to automatically omit them when empty." %}
+          </p>
         </div>
       </div>
     </div>

--- a/socialmedia/templates/socialmedia/settings_form.html
+++ b/socialmedia/templates/socialmedia/settings_form.html
@@ -174,7 +174,7 @@
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{talk_title}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{hashtags}</span>
           </div>
-          <p class="help-block text-muted" style="font-size: 11px; margin-top: 5px;">
+          <p class="help-block text-muted sm-placeholder-help">
             {% trans "Note: Handle placeholders output as @username across supported networks. Wrap optional placeholders in parentheses () or brackets [] to automatically omit them when empty." %}
           </p>
         </div>
@@ -303,7 +303,7 @@
       </div>
     </div>
 
-    <div style="padding-top: 10px; border-top: 1px solid #eee; display:flex; gap:10px;">
+    <div class="sm-preview-actions">
       <button type="submit" name="action" value="save" class="btn btn-primary">
         <i class="fa fa-save"></i> {% trans "Save Settings" %}
       </button>
@@ -312,12 +312,7 @@
       </button>
     </div>
   </form>
+</div><!-- /sm-page -->
 
-<script id="socialmedia-config" type="application/json">
-{
-  "csrfToken": "{{ csrf_token }}"
-}
-</script>
-<link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
 <script src="{% static 'socialmedia/js/settings.js' %}"></script>
 {% endblock %}

--- a/socialmedia/templates/socialmedia/settings_form.html
+++ b/socialmedia/templates/socialmedia/settings_form.html
@@ -166,6 +166,9 @@
             <span class="tokens-label">{% trans "Insert Placeholders:" %}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{event_name}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_name}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_social_handle}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_twitter}</span>
+            <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_linkedin}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{speaker_link}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{talk_title}</span>
             <span class="token-chip" data-target="id_socialmedia_speaker_template">{hashtags}</span>
@@ -306,7 +309,11 @@
     </div>
   </form>
 
-</div><!-- /sm-page -->
+<script id="socialmedia-config" type="application/json">
+{
+  "csrfToken": "{{ csrf_token }}"
+}
+</script>
 <link rel="stylesheet" type="text/css" href="{% static 'socialmedia/css/settings.css' %}">
 <script src="{% static 'socialmedia/js/settings.js' %}"></script>
 {% endblock %}

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -329,8 +329,9 @@ def preview_posts(request, organizer, event):
                 p["error_message"] = ""
                 p["media_url"] = p.get("media_url") or ""
             posts.append(p)
-    except Exception:  # pragma: no cover
-        return JsonResponse({"error": "Internal server error"}, status=500)
+    except Exception as exc:  # pragma: no cover
+        logger.exception("Error generating preview posts: %s", exc)
+        return JsonResponse({"error": str(exc)}, status=500)
     return JsonResponse({"posts": posts})
 
 

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -331,7 +331,7 @@ def preview_posts(request, organizer, event):
             posts.append(p)
     except Exception as exc:  # pragma: no cover
         logger.exception("Error generating preview posts: %s", exc)
-        return JsonResponse({"error": str(exc)}, status=500)
+        return JsonResponse({"error": "Internal server error"}, status=500)
     return JsonResponse({"posts": posts})
 
 

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -422,7 +422,8 @@ def update_post(request, organizer, event):
         )
     except (json.JSONDecodeError, ValueError) as exc:
         return JsonResponse({"error": str(exc)}, status=400)
-    except Exception:
+    except Exception as exc:
+        logger.exception("Error updating post: %s", exc)
         return JsonResponse({"error": "Internal server error"}, status=500)
 
 

--- a/tests/test_speaker_social.py
+++ b/tests/test_speaker_social.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock
+import pytest
+from socialmedia.export import _extract_speaker_social_info, safe_format
+
+
+class DummyLink:
+    def __init__(self, network, url, path=""):
+        self.network = network
+        self.url = url
+        self.path = path
+
+
+class DummySpeaker:
+    def __init__(self, display_name="Alice Smith", links=None):
+        self._display_name = display_name
+        self.pk = 1
+        self.code = "ALICE1"
+        self._links = links or []
+
+    def get_display_name(self):
+        return self._display_name
+
+    @property
+    def social_links(self):
+        manager = MagicMock()
+        manager.all.return_value = self._links
+        return manager
+
+
+def test_extract_speaker_social_info_empty():
+    info, links = _extract_speaker_social_info(None)
+    assert info["speaker_social_handle"] == ""
+    assert links == []
+
+
+def test_extract_speaker_social_info_with_links():
+    speaker = DummySpeaker(
+        "Alice Smith",
+        links=[
+            DummyLink("twitter", "https://x.com/alice_smith", "alice_smith"),
+            DummyLink("linkedin", "https://linkedin.com/in/alice-smith", "alice-smith"),
+        ],
+    )
+    info, links = _extract_speaker_social_info(speaker, target_platform="twitter")
+    assert info["speaker_social_handle"] == "@alice_smith"
+    assert info["speaker_twitter"] == "@alice_smith"
+    assert info["speaker_linkedin"] == "https://linkedin.com/in/alice-smith"
+    assert len(links) == 2
+    assert links[0]["network"] == "twitter"
+    assert links[0]["handle"] == "@alice_smith"
+
+
+def test_safe_format_with_handles():
+    tmpl = "Meet {speaker_name} ({speaker_social_handle}) at {event_name}!"
+    out = safe_format(tmpl, speaker_name="Alice", speaker_social_handle="@alice", event_name="PyCon")
+    assert out == "Meet Alice (@alice) at PyCon!"
+
+
+def test_safe_format_empty_handle_cleanup():
+    tmpl = "Meet {speaker_name} ({speaker_social_handle}) at {event_name}!"
+    out = safe_format(tmpl, speaker_name="Alice", speaker_social_handle="", event_name="PyCon")
+    assert out == "Meet Alice at PyCon!"
+
+
+def test_extract_speaker_social_info_user_instance():
+    profile = DummySpeaker("Alice User", links=[DummyLink("twitter", "https://x.com/alice_user", "alice_user")])
+    user = MagicMock()
+    user.event_profile.return_value = profile
+    event = MagicMock()
+
+    info, links = _extract_speaker_social_info(user, event=event)
+    assert info["speaker_social_handle"] == "@alice_user"
+    assert len(links) == 1
+
+
+def test_custom_template_priority_over_platform_defaults():
+    event = MagicMock()
+    event.settings.get.side_effect = lambda key, default=None, **kwargs: (
+        "Custom Speaker Template {speaker_name} ({speaker_social_handle})" if key == "socialmedia_speaker_template" else default
+    )
+    from socialmedia.export import _get_platform_template
+    tpl = _get_platform_template(event, "speaker", "twitter", "announcement")
+    assert tpl == "Custom Speaker Template {speaker_name} ({speaker_social_handle})"
+
+
+def test_platform_default_templates_contain_social_handles():
+    from socialmedia.export import PLATFORM_DEFAULT_TEMPLATES
+    for platform in ["twitter", "telegram", "linkedin", "mastodon"]:
+        speaker_tpl = PLATFORM_DEFAULT_TEMPLATES[platform]["speaker"]["announcement"]
+        assert "{speaker_social_handle}" in speaker_tpl, f"Missing in {platform} speaker announcement"
+
+        session_tpl = PLATFORM_DEFAULT_TEMPLATES[platform]["session"]["announcement"]
+        assert "{speaker_social_handles}" in session_tpl, f"Missing in {platform} session announcement"

--- a/tests/test_speaker_social.py
+++ b/tests/test_speaker_social.py
@@ -44,10 +44,25 @@ def test_extract_speaker_social_info_with_links():
     info, links = _extract_speaker_social_info(speaker, target_platform="twitter")
     assert info["speaker_social_handle"] == "@alice_smith"
     assert info["speaker_twitter"] == "@alice_smith"
-    assert info["speaker_linkedin"] == "https://linkedin.com/in/alice-smith"
+    assert info["speaker_linkedin"] == "@alice-smith"
+    assert info["speaker_linkedin_url"] == "https://linkedin.com/in/alice-smith"
     assert len(links) == 2
     assert links[0]["network"] == "twitter"
     assert links[0]["handle"] == "@alice_smith"
+
+
+def test_extract_speaker_social_info_target_platform_mismatch():
+    speaker = DummySpeaker(
+        "Bob Jones",
+        links=[
+            DummyLink("linkedin", "https://linkedin.com/in/bob-jones", "bob-jones"),
+        ],
+    )
+    # Target platform is twitter, but speaker only has linkedin
+    info, links = _extract_speaker_social_info(speaker, target_platform="twitter")
+    assert info["speaker_social_handle"] == ""
+    assert info["speaker_linkedin"] == "@bob-jones"
+    assert info["speaker_linkedin_url"] == "https://linkedin.com/in/bob-jones"
 
 
 def test_safe_format_with_handles():
@@ -57,8 +72,8 @@ def test_safe_format_with_handles():
 
 
 def test_safe_format_empty_handle_cleanup():
-    tmpl = "Meet {speaker_name} ({speaker_social_handle}) at {event_name}!"
-    out = safe_format(tmpl, speaker_name="Alice", speaker_social_handle="", event_name="PyCon")
+    tmpl = "Meet {speaker_name} ({speaker_social_handle}) [{speaker_twitter}] at {event_name}!"
+    out = safe_format(tmpl, speaker_name="Alice", speaker_social_handle="", speaker_twitter="", event_name="PyCon")
     assert out == "Meet Alice at PyCon!"
 
 


### PR DESCRIPTION
## Description

Following the organizer-configurable speaker social links implementation in Eventyay ([fossasia/eventyay#4435](https://github.com/fossasia/eventyay/pull/4435)), this PR addresses [fossasia/eventyay-socialmedia#45](https://github.com/fossasia/eventyay-socialmedia/issues/45) by extracting speaker social media handles and profile URLs, adding placeholder tokens to settings forms, defaulting platform templates to include social handles, and rendering clickable speaker profile badges in live post previews and post list rows.
<img width="1438" height="295" alt="260814_17h10m42s_screenshot" src="https://github.com/user-attachments/assets/a0a62ee1-094e-485e-ac23-082e066ea07c" />
<img width="748" height="718" alt="260814_17h11m08s_screenshot" src="https://github.com/user-attachments/assets/59d4d88c-fbbc-43fd-9578-f73faea881d1" />


- Resolves #45

---

## Changes Included

### 1. Data Extraction & Template Placeholders (`socialmedia/export.py`)
- Implemented `_extract_speaker_social_info` to extract network handles and profile URLs (`twitter`/`x`, `linkedin`, `github`, `mastodon`, `telegram`, `instagram`, `website`).
- Corrected `User.event_profile(event)` resolution and updated query prefetching (`speakers__profiles__social_links`).
- Introduced template placeholders: `{speaker_social_handle}`, `{speaker_twitter}`, `{speaker_linkedin}`, `{speaker_github}`, `{speaker_mastodon}`, `{speaker_telegram}`, `{speaker_instagram}`, `{speaker_website}`, `{speaker_social_link}`, and `{speaker_social_handles}` (for multi-speaker sessions).
- Updated `PLATFORM_DEFAULT_TEMPLATES` across all platforms (**X/Twitter**, **LinkedIn**, **Telegram**, **Mastodon**) to include `{speaker_social_handle}` and `{speaker_social_handles}` by default in speaker and session templates.
- Fixed template resolution priority in `_get_platform_template` so organizer-saved custom generic templates (`socialmedia_speaker_template`) take precedence over built-in system defaults.
- Enhanced `safe_format` to automatically strip empty parentheses `()` or double spaces when a speaker has no social links configured.

### 2. Frontend UI, Previews & Token Chips (`settings.js`, `settings.html`, `settings_form.html`)
- Added a **Speaker Profiles** section in the **Post Live Preview Modal** rendering clickable badges leading directly to external speaker profiles (`target="_blank" rel="noopener"`).
- Rendered social link badges in the **Post List Table** content rows under speaker posts.
- Added insertable placeholder chips for `{speaker_social_handle}`, `{speaker_twitter}`, `{speaker_linkedin}` in template settings forms.
- Fixed `Config` initialization in `settings.js` to parse safely without aborting script execution on form views.
- Updated `insertToken()` to insert tokens into the currently focused input/textarea and added global document event delegation.
- Fixed quick preset buttons (`30d`, `14d`, `7d`, etc.) to trigger `"input"` and `"change"` events and update active offset badge styling in real-time.

### 3. Automated Tests (`tests/test_speaker_social.py`)
- Added unit tests covering:
  - Extraction of speaker social handles and URLs for various networks.
  - User instance profile resolution via `event_profile(event)`.
  - Placeholder substitution and graceful empty handle cleanup.
  - Custom generic template priority over baked-in platform defaults.
  - Presence of social handle placeholders in platform default templates.

---

## How to Test

1. **Unit Tests**:
   ```bash
   .venv/bin/pytest tests/test_speaker_social.py
   .venv/bin/pytest tests/test_views.py
   ```
2. **Web UI**:
   - Navigate to Event **Social Media Settings** -> **Speaker**.
   - Click placeholder chip `{speaker_social_handle}` or offset preset buttons; verify field values and active offset pill labels update instantly.
   - Save settings and generate posts for an event with confirmed speakers having social profiles configured.
   - Verify post copy contains speaker handles (e.g., `@john_doe`).
   - Click **Eye (Preview)** icon on a speaker post: verify clickable social badges open speaker profile links in a new tab.
```

## Summary by Sourcery

Support speaker social handles and profile links throughout post generation, customization, previews, and post listings.

New Features:
- Add speaker social handles and profile URLs to generated speaker and session posts across supported social platforms.
- Show clickable speaker profile badges in post previews and post list rows.

Bug Fixes:
- Ensure organizer-saved generic templates take precedence over built-in platform defaults.
- Clean up empty optional social placeholders and make settings-page configuration parsing resilient.

Enhancements:
- Provide social-network template placeholders and improve token insertion and schedule preset interactions in the settings UI.
- Add logging around recoverable export, provider, encryption, and view errors.

Tests:
- Add automated coverage for social-link extraction, template formatting, profile resolution, template precedence, and platform defaults.