### PR TITLE
fix: enable automated publishing toggle and draft reschedule transition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ maintainers = [
 
 dependencies = [
     "Mastodon.py",
+    "cryptography",
 ]
 
 [project.entry-points."pretix.plugin"]

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -5,6 +5,7 @@ import re
 from datetime import timedelta
 
 import pytz
+from django.utils import timezone
 from django.utils.timezone import is_naive, make_aware
 
 logger = logging.getLogger(__name__)
@@ -1174,6 +1175,12 @@ def sync_posts_to_db(event, request=None):
             logger.warning("Error parsing datetime string '%s': %s", dt_str, exc)
             continue
 
+        now_dt = timezone.now()
+        initial_status = (
+            SocialMediaPostStatus.DRAFT
+            if scheduled_at < now_dt
+            else SocialMediaPostStatus.SCHEDULED
+        )
         offset_val = p.get("offset_days", 0)
         db_post, created = SocialMediaPost.objects.get_or_create(
             event=event,
@@ -1185,7 +1192,7 @@ def sync_posts_to_db(event, request=None):
                 "post_text": p["post_text"],
                 "media_url": p.get("media_url"),
                 "template_context": p.get("template_context", "announcement"),
-                "status": SocialMediaPostStatus.SCHEDULED,
+                "status": initial_status,
             },
         )
         if not created and not db_post.is_pinned:
@@ -1194,6 +1201,10 @@ def sync_posts_to_db(event, request=None):
             if "media_url" in p and p["media_url"] is not None:
                 db_post.media_url = p["media_url"]
             db_post.template_context = p.get("template_context", "announcement")
+            if db_post.status == SocialMediaPostStatus.SCHEDULED and scheduled_at < now_dt:
+                db_post.status = SocialMediaPostStatus.DRAFT
+            elif db_post.status == SocialMediaPostStatus.DRAFT and scheduled_at >= now_dt:
+                db_post.status = SocialMediaPostStatus.SCHEDULED
             db_post.save()
 
     # Clean up obsolete non-pinned, non-custom posts that are no longer generated.

--- a/socialmedia/forms.py
+++ b/socialmedia/forms.py
@@ -136,6 +136,16 @@ class SocialMediaSettingsForm(SettingsForm):
         required=False,
         max_length=200,
     )
+    socialmedia_auto_publish = forms.BooleanField(
+        label=_("Automatically Publish Scheduled Posts"),
+        help_text=_(
+            "When enabled, scheduled posts for direct integrations (e.g. Telegram, Mastodon) "
+            "are published automatically at their scheduled time by the background worker. "
+            "When disabled, posts remain as drafts until manually approved or pinned."
+        ),
+        required=False,
+        initial=True,
+    )
 
     # ------------------------------------------------------------------
     # Platform toggles  (order: Twitter, LinkedIn, Telegram, Mastodon)

--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -164,12 +164,12 @@ def claim_post_for_publishing(post_pk, provider_name):
             locked_post.error_message = (
                 f"No active {provider_name} account found for organizer."
             )
-            locked_post.save(update_fields=["status", "error_message"])
+            locked_post.save(update_fields=["status", "error_message", "updated_at"])
             return None, None
 
         locked_post.status = SocialMediaPostStatus.EXPORTED
         locked_post.error_message = ""
-        locked_post.save(update_fields=["status", "error_message"])
+        locked_post.save(update_fields=["status", "error_message", "updated_at"])
         return locked_post, account
 
 

--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -182,13 +182,23 @@ def publish_scheduled_posts(sender, **kwargs):
     """
     from .tasks import publish_single_post
 
-    due_posts = SocialMediaPost.objects.filter(
-        status=SocialMediaPostStatus.SCHEDULED,
-        is_pinned=True,
-        scheduled_at__lte=now(),
-    ).order_by("scheduled_at", "pk")
+    due_posts = (
+        SocialMediaPost.objects.select_related("event")
+        .filter(
+            status=SocialMediaPostStatus.SCHEDULED,
+            scheduled_at__lte=now(),
+        )
+        .order_by("scheduled_at", "pk")
+    )
 
     for post in due_posts:
+        # Check event setting: auto-publish enabled or explicit pin required
+        auto_publish = post.event.settings.get(
+            "socialmedia_auto_publish", as_type=bool, default=True
+        )
+        if not auto_publish and not post.is_pinned:
+            continue
+
         entity_id = post.entity_id or ""
         provider_names = []
         if any(entity_id.endswith(f"_{prov}") for prov in SCHEDULER_PROVIDERS):

--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.db import transaction
 from django.dispatch import receiver
@@ -131,13 +133,17 @@ def control_dashboard_socialmedia(sender, request=None, **kwargs):
     )
 
 
-def claim_post_for_publishing(post_pk, provider_name):
+logger = logging.getLogger(__name__)
+
+
+def claim_post_for_publishing(post_pk: int, provider_name: str):
     """Atomically claim a scheduled or failed post for publishing.
 
     Transitions status to EXPORTED while holding select_for_update row lock,
     releasing the lock immediately upon commit before HTTP network calls.
     Returns (claimed_post, account) or (None, None) if unavailable.
     """
+    logger.debug("Attempting to claim post %s for provider %s.", post_pk, provider_name)
     with transaction.atomic():
         locked_post = (
             SocialMediaPost.objects.filter(
@@ -151,6 +157,10 @@ def claim_post_for_publishing(post_pk, provider_name):
             .first()
         )
         if not locked_post:
+            logger.info(
+                "Post %s could not be locked for publishing (already claimed, running, or not in SCHEDULED/FAILED state).",
+                post_pk,
+            )
             return None, None
 
         account = SocialMediaAccount.objects.filter(
@@ -165,11 +175,22 @@ def claim_post_for_publishing(post_pk, provider_name):
                 f"No active {provider_name} account found for organizer."
             )
             locked_post.save(update_fields=["status", "error_message", "updated_at"])
+            logger.warning(
+                "Post %s marked as FAILED: No active %s account found for organizer '%s'.",
+                post_pk,
+                provider_name,
+                locked_post.event.organizer.slug,
+            )
             return None, None
 
         locked_post.status = SocialMediaPostStatus.EXPORTED
         locked_post.error_message = ""
         locked_post.save(update_fields=["status", "error_message", "updated_at"])
+        logger.info(
+            "Post %s successfully claimed for %s (status transitioned to EXPORTED).",
+            post_pk,
+            provider_name,
+        )
         return locked_post, account
 
 
@@ -183,7 +204,7 @@ def publish_scheduled_posts(sender, **kwargs):
     from .tasks import publish_single_post
 
     due_posts = (
-        SocialMediaPost.objects.select_related("event")
+        SocialMediaPost.objects.select_related("event", "event__organizer")
         .filter(
             status=SocialMediaPostStatus.SCHEDULED,
             scheduled_at__lte=now(),
@@ -191,17 +212,31 @@ def publish_scheduled_posts(sender, **kwargs):
         .order_by("scheduled_at", "pk")
     )
 
+    count = due_posts.count()
+    if count > 0:
+        logger.info("Social media periodic runner found %d due post(s) to process.", count)
+
     for post in due_posts:
         # Check event setting: auto-publish enabled or explicit pin required
         auto_publish = post.event.settings.get(
             "socialmedia_auto_publish", as_type=bool, default=True
         )
         if not auto_publish and not post.is_pinned:
+            logger.info(
+                "Skipping post %s (event '%s'): socialmedia_auto_publish is False and post is unpinned.",
+                post.pk,
+                post.event.slug,
+            )
             continue
 
         entity_id = post.entity_id or ""
         provider_names = []
         if any(entity_id.endswith(f"_{prov}") for prov in SCHEDULER_PROVIDERS):
+            logger.debug(
+                "Skipping post %s (entity '%s'): belongs to external scheduler provider.",
+                post.pk,
+                entity_id,
+            )
             continue
 
         for prov in DIRECT_PUBLISH_PROVIDERS:
@@ -222,10 +257,26 @@ def publish_scheduled_posts(sender, **kwargs):
             )
             provider_names = active_provs
 
+        if not provider_names:
+            logger.warning(
+                "Post %s (event '%s', scheduled for %s) has no active direct providers (Telegram/Mastodon) configured.",
+                post.pk,
+                post.event.slug,
+                post.scheduled_at,
+            )
+            continue
+
         for provider_name in provider_names:
-            if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False) or getattr(
+            is_eager = getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False) or getattr(
                 settings, "CELERY_ALWAYS_EAGER", False
-            ):
+            )
+            logger.info(
+                "Dispatching publish_single_post for post %s to provider %s (eager=%s).",
+                post.pk,
+                provider_name,
+                is_eager,
+            )
+            if is_eager:
                 publish_single_post(post.pk, provider_name)
             else:
                 publish_single_post.apply_async(args=[post.pk, provider_name])

--- a/socialmedia/tasks.py
+++ b/socialmedia/tasks.py
@@ -30,10 +30,10 @@ def publish_single_post(post_pk: int, provider_name: str):
         provider.publish_post(text=claimed_post.post_text, media=media)
         claimed_post.status = SocialMediaPostStatus.PUBLISHED
         claimed_post.error_message = ""
-        claimed_post.save(update_fields=["status", "error_message"])
+        claimed_post.save(update_fields=["status", "error_message", "updated_at"])
         logger.info(f"Successfully published post {post_pk} to {provider_name}.")
     except Exception as e:
         logger.error(f"Failed to publish post {post_pk} to {provider_name}: {e}")
         claimed_post.status = SocialMediaPostStatus.FAILED
         claimed_post.error_message = str(e)
-        claimed_post.save(update_fields=["status", "error_message"])
+        claimed_post.save(update_fields=["status", "error_message", "updated_at"])

--- a/socialmedia/tasks.py
+++ b/socialmedia/tasks.py
@@ -16,24 +16,46 @@ def publish_single_post(post_pk: int, provider_name: str):
     Claims the post using database row locking (select_for_update) and executes
     the provider's publish_post call off the main periodic beat thread.
     """
+    logger.info(
+        "Executing publish_single_post task for post %s (provider: %s).",
+        post_pk,
+        provider_name,
+    )
     claimed_post, account = claim_post_for_publishing(post_pk, provider_name)
     if not claimed_post or not account:
-        logger.info(
-            f"Post {post_pk} could not be claimed or active account "
-            f"missing for provider {provider_name}."
+        logger.warning(
+            "Post %s could not be claimed or active %s account missing for organizer.",
+            post_pk,
+            provider_name,
         )
         return
 
     try:
         provider = get_provider(account)
         media = [claimed_post.media_url] if claimed_post.media_url else None
+        logger.info(
+            "Calling %s API to publish post %s (with_media=%s)...",
+            provider_name,
+            post_pk,
+            bool(media),
+        )
         provider.publish_post(text=claimed_post.post_text, media=media)
         claimed_post.status = SocialMediaPostStatus.PUBLISHED
         claimed_post.error_message = ""
         claimed_post.save(update_fields=["status", "error_message", "updated_at"])
-        logger.info(f"Successfully published post {post_pk} to {provider_name}.")
+        logger.info(
+            "Successfully published post %s to %s (status -> PUBLISHED).",
+            post_pk,
+            provider_name,
+        )
     except Exception as e:
-        logger.error(f"Failed to publish post {post_pk} to {provider_name}: {e}")
+        logger.error(
+            "Failed to publish post %s to %s: %s (status -> FAILED).",
+            post_pk,
+            provider_name,
+            e,
+            exc_info=True,
+        )
         claimed_post.status = SocialMediaPostStatus.FAILED
         claimed_post.error_message = str(e)
         claimed_post.save(update_fields=["status", "error_message", "updated_at"])

--- a/socialmedia/templates/socialmedia/log.html
+++ b/socialmedia/templates/socialmedia/log.html
@@ -60,20 +60,16 @@
             </span>
           </td>
           <td>
-            {% if post.entity_id %}
-              {% for platform in platforms %}
-                {% if platform in post.entity_id %}
-                  <span class="sm-platform-badge sm-platform-{{ platform }}">
-                    {% if platform == "telegram" %}<i class="fa fa-paper-plane"></i>{% endif %}
-                    {% if platform == "mastodon" %}<i class="fa fa-bullhorn"></i>{% endif %}
-                    {% if platform == "twitter" %}<i class="fa fa-twitter"></i>{% endif %}
-                    {% if platform == "linkedin" %}<i class="fa fa-linkedin"></i>{% endif %}
-                    {{ platform|capfirst }}
-                  </span>
-                {% endif %}
-              {% endfor %}
+            {% if "telegram" in post.entity_id %}
+              <span class="sm-platform-badge sm-platform-telegram"><i class="fa fa-paper-plane"></i> Telegram</span>
+            {% elif "mastodon" in post.entity_id %}
+              <span class="sm-platform-badge sm-platform-mastodon"><i class="fa fa-bullhorn"></i> Mastodon</span>
+            {% elif "twitter" in post.entity_id %}
+              <span class="sm-platform-badge sm-platform-twitter"><i class="fa fa-twitter"></i> Twitter</span>
+            {% elif "linkedin" in post.entity_id %}
+              <span class="sm-platform-badge sm-platform-linkedin"><i class="fa fa-linkedin"></i> LinkedIn</span>
             {% else %}
-              <span class="sm-platform-badge">{% trans "Generic" %}</span>
+              <span class="sm-platform-badge sm-platform-generic">{% trans "Generic" %}</span>
             {% endif %}
           </td>
           <td class="sm-log-content">

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -225,6 +225,7 @@
           <div class="adv-group-title"><i class="fa fa-globe"></i> {% trans "Global" %}</div>
           {% bootstrap_field form.socialmedia_event_link layout="horizontal" %}
           {% bootstrap_field form.socialmedia_default_hashtags layout="horizontal" %}
+          {% bootstrap_field form.socialmedia_auto_publish layout="horizontal" %}
         </div>
 
         <!-- CFP -->

--- a/socialmedia/templates/socialmedia/settings_form.html
+++ b/socialmedia/templates/socialmedia/settings_form.html
@@ -94,6 +94,7 @@
       <div class="adv-group-title"><i class="fa fa-globe"></i> {% trans "Global" %}</div>
       {% bootstrap_field form.socialmedia_event_link layout="horizontal" %}
       {% bootstrap_field form.socialmedia_default_hashtags layout="horizontal" %}
+      {% bootstrap_field form.socialmedia_auto_publish layout="horizontal" %}
     </div>
 
     <!-- CFP -->

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -380,9 +380,10 @@ def update_post(request, organizer, event):
             new_scheduled_at = tz.localize(naive_dt)
             db_post.scheduled_at = new_scheduled_at
 
-            # When the organizer moves a post to a future time, reset any terminal
-            # or done status back to SCHEDULED so Celery Beat picks it up again.
-            _terminal_statuses = (
+            # When the organizer moves a post to a future time, reset any terminal,
+            # draft, or failed status back to SCHEDULED so Celery Beat picks it up.
+            _reschedulable_statuses = (
+                SocialMediaPostStatus.DRAFT,
                 SocialMediaPostStatus.PUBLISHED,
                 SocialMediaPostStatus.EXPORTED,
                 SocialMediaPostStatus.FAILED,
@@ -390,7 +391,8 @@ def update_post(request, organizer, event):
             )
             if (
                 new_scheduled_at > timezone.now()
-                and db_post.status in _terminal_statuses
+                and db_post.status in _reschedulable_statuses
+                and (status is None or status == SocialMediaPostStatus.SCHEDULED)
             ):
                 db_post.status = SocialMediaPostStatus.SCHEDULED
                 db_post.error_message = ""
@@ -399,6 +401,12 @@ def update_post(request, organizer, event):
                     db_post.pk,
                     new_scheduled_at,
                 )
+            elif (
+                new_scheduled_at <= timezone.now()
+                and db_post.status == SocialMediaPostStatus.SCHEDULED
+                and status is None
+            ):
+                db_post.status = SocialMediaPostStatus.DRAFT
 
         if is_pinned is not None:
             db_post.is_pinned = is_pinned

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -871,7 +871,7 @@ def publish_post_now(request, organizer, event):
             db_post = locked_post
             db_post.status = SocialMediaPostStatus.EXPORTED
             db_post.error_message = ""
-            db_post.save(update_fields=["status", "error_message"])
+            db_post.save(update_fields=["status", "error_message", "updated_at"])
 
         entity_id = db_post.entity_id or ""
         provider_name = None

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -931,6 +931,12 @@ def publish_post_now(request, organizer, event):
             else:
                 db_post.error_message = err_details
             db_post.save()
+            logger.error(
+                "Manual publishing failed for post %s (event '%s'): %s",
+                db_post.pk,
+                request.event.slug,
+                db_post.error_message,
+            )
             return JsonResponse(
                 {
                     "success": False,
@@ -948,6 +954,13 @@ def publish_post_now(request, organizer, event):
         )
         db_post.error_message = ""
         db_post.save()
+        logger.info(
+            "Manual publishing succeeded for post %s (event '%s', providers: %s, status -> %s).",
+            db_post.pk,
+            request.event.slug,
+            published_providers,
+            db_post.status,
+        )
 
         return JsonResponse(
             {

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -186,7 +186,7 @@ def test_publish_scheduled_posts_future_or_other_status(organizer, event, settin
 
 
 @pytest.mark.django_db
-def test_publish_scheduled_posts_ignores_unpinned_stale_generated_posts(
+def test_publish_scheduled_posts_auto_publishes_unpinned_posts_when_enabled(
     organizer, event, settings
 ):
     settings.CELERY_TASK_ALWAYS_EAGER = True
@@ -200,12 +200,52 @@ def test_publish_scheduled_posts_ignores_unpinned_stale_generated_posts(
     account.save()
 
     with scope(organizer=organizer, event=event):
+        event.settings.set("socialmedia_auto_publish", True)
         post = SocialMediaPost.objects.create(
             event=event,
             post_type="cfp",
             entity_id="cfp_1_telegram",
-            scheduled_at=now() - timedelta(days=30),
-            post_text="Old generated post",
+            scheduled_at=now() - timedelta(minutes=5),
+            post_text="Unpinned auto published post",
+            status=SocialMediaPostStatus.SCHEDULED,
+            is_pinned=False,
+        )
+
+    with patch.object(
+        TelegramProvider,
+        "publish_post",
+        return_value={"post_id": "123", "url": "https://t.me/123"},
+    ) as mock_publish:
+        publish_scheduled_posts(sender=None)
+        mock_publish.assert_called_once_with(text="Unpinned auto published post", media=None)
+
+    with scope(organizer=organizer, event=event):
+        post.refresh_from_db()
+        assert post.status == SocialMediaPostStatus.PUBLISHED
+
+
+@pytest.mark.django_db
+def test_publish_scheduled_posts_skips_unpinned_when_auto_publish_disabled(
+    organizer, event, settings
+):
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    account = SocialMediaAccount.objects.create(
+        organizer=organizer,
+        provider="telegram",
+        platform_username="test_channel",
+        is_active=True,
+    )
+    account.credentials = {"bot_token": "fake_token"}
+    account.save()
+
+    with scope(organizer=organizer, event=event):
+        event.settings.set("socialmedia_auto_publish", False)
+        post = SocialMediaPost.objects.create(
+            event=event,
+            post_type="cfp",
+            entity_id="cfp_1_telegram",
+            scheduled_at=now() - timedelta(minutes=5),
+            post_text="Unpinned post should be skipped",
             status=SocialMediaPostStatus.SCHEDULED,
             is_pinned=False,
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,9 @@
 import json
+from datetime import timedelta
 
 import pytest
 from django.urls import reverse
+from django.utils.timezone import now
 from django_scopes import scope
 
 
@@ -72,6 +74,7 @@ def test_socialmedia_settings_view_post(
             "socialmedia_schedule_enabled": "on",
             "socialmedia_schedule_offset": "1",
             "socialmedia_schedule_template": "Schedule: {schedule_link}",
+            "socialmedia_auto_publish": "on",
         },
     )
 
@@ -90,6 +93,7 @@ def test_socialmedia_settings_view_post(
             event.settings.get("socialmedia_cfp_template")
             == "CFP Deadline: {cfp_deadline}"
         )
+        assert event.settings.get("socialmedia_auto_publish", as_type=bool) is True
 
 
 @pytest.mark.django_db
@@ -180,6 +184,51 @@ def test_update_post_reschedule_future_requeues_for_publishing(
         assert post.status == SocialMediaPostStatus.SCHEDULED
         assert post.is_pinned is True
         assert post.error_message == ""
+
+
+@pytest.mark.django_db
+def test_update_post_reschedule_draft_to_future_becomes_scheduled(
+    logged_in_organizer_client, organizer, event, settings
+):
+    settings.SITE_URL = "https://testserver"
+    import pytz
+    from django.utils import timezone
+    from socialmedia.models import SocialMediaPost, SocialMediaPostStatus
+
+    event_tz = pytz.timezone(getattr(event, "timezone", None) or "UTC")
+    future_dt = timezone.now().astimezone(event_tz) + timedelta(days=2)
+
+    with scope(organizer=organizer, event=event):
+        post = SocialMediaPost.objects.create(
+            event=event,
+            post_type="custom",
+            entity_id="custom_draft_1",
+            scheduled_at=timezone.now() - timedelta(days=1),
+            post_text="Draft post",
+            status=SocialMediaPostStatus.DRAFT,
+            is_pinned=False,
+        )
+
+    url = reverse(
+        "plugins:socialmedia:update",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    payload = {
+        "db_id": post.pk,
+        "post_date": future_dt.strftime("%Y-%m-%d"),
+        "post_time": future_dt.strftime("%H:%M"),
+    }
+    response = logged_in_organizer_client.post(
+        url, data=json.dumps(payload), content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["post_status"] == SocialMediaPostStatus.SCHEDULED
+
+    with scope(organizer=organizer, event=event):
+        post.refresh_from_db()
+        assert post.status == SocialMediaPostStatus.SCHEDULED
+        assert post.is_pinned is True
 
 
 @pytest.mark.django_db
@@ -300,6 +349,8 @@ def test_multi_offset_generation_and_db_sync(organizer, event):
 
     with scope(organizer=organizer, event=event):
         event = event.__class__.objects.get(pk=event.pk)
+        event.date_from = now() + timedelta(days=60)
+        event.save()
         sub_type = event.submission_types.first() or SubmissionType.objects.create(
             event=event, name="Talk"
         )
@@ -324,6 +375,31 @@ def test_multi_offset_generation_and_db_sync(organizer, event):
         db_posts = SocialMediaPost.objects.filter(event=event, post_type="speaker")
         assert db_posts.count() == 3
         assert all(p.status == SocialMediaPostStatus.SCHEDULED for p in db_posts)
+
+
+@pytest.mark.django_db
+def test_sync_posts_to_db_past_draft_future_scheduled(organizer, event):
+    from socialmedia.export import build_posts, sync_posts_to_db
+    from socialmedia.models import SocialMediaPost, SocialMediaPostStatus
+
+    with scope(organizer=organizer, event=event):
+        # Event in the past
+        event = event.__class__.objects.get(pk=event.pk)
+        event.date_from = now() - timedelta(days=60)
+        event.save()
+
+        posts = build_posts(event)
+        if posts:
+            sync_posts_to_db(event)
+            past_posts = SocialMediaPost.objects.filter(event=event)
+            assert all(p.status == SocialMediaPostStatus.DRAFT for p in past_posts)
+
+        # Event in the future
+        event.date_from = now() + timedelta(days=60)
+        event.save()
+        sync_posts_to_db(event)
+        future_posts = SocialMediaPost.objects.filter(event=event)
+        assert any(p.status == SocialMediaPostStatus.SCHEDULED for p in future_posts)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #53 

### Summary of Changes
- **Auto-Publish Setting:** Added `socialmedia_auto_publish` setting in Global Settings to allow organizers to control automated hands-free publishing.
- **Smart Generation Defaults:** Stored past sessions/CFPs as `DRAFT` to avoid blasting historical posts while scheduling future ones as `SCHEDULED`.
- **Dispatcher:** Updated periodic worker signal to publish all due `SCHEDULED` posts when auto-publish is enabled.
- **Reschedule Fix:** Updated `update_post` view so rescheduling a `DRAFT` post to a future date/time automatically updates its status to `SCHEDULED`.
- **Tests:** Added test cases covering auto-publish enabled/disabled behavior and draft-to-scheduled transitions.

https://github.com/user-attachments/assets/7bf21f95-e1d0-4ece-9dde-781bcee3d0a0


## Summary by Sourcery

Enable configurable automatic publishing while making generated and rescheduled post statuses reflect whether their scheduled times are in the past or future.

New Features:
- Add an organizer setting to control automatic publishing of scheduled social media posts.
- Automatically publish due scheduled posts when enabled while retaining manual approval behavior when disabled.

Bug Fixes:
- Prevent historical generated posts from being automatically published by storing past posts as drafts.
- Reschedule draft posts into the scheduled state when moved to a future date and return scheduled posts to drafts when moved into the past.

Enhancements:
- Keep post modification timestamps current during publishing and status transitions.
- Improve platform labeling in the social media log.

Build:
- Add the cryptography dependency.

Tests:
- Cover automatic publishing settings, draft-to-scheduled rescheduling, and past-versus-future post synchronization.

## Summary by Sourcery

Enable configurable automatic publishing and keep social media post statuses aligned with their scheduled times.

New Features:
- Add an organizer setting to control whether due scheduled social media posts are published automatically or require manual approval.

Bug Fixes:
- Prevent generated posts for past sessions and CFPs from being treated as scheduled for publication.
- Synchronize post statuses with their scheduled times and reschedule draft posts into the scheduled state when moved to the future.

Enhancements:
- Improve publishing lifecycle tracking, logging, and platform labels in the social media log.

Build:
- Add the cryptography dependency.

Tests:
- Add coverage for automatic publishing behavior, rescheduling drafts, and past-versus-future status synchronization.