### PR TITLE
Improve social media pages layout and remove nested scrollbars

### DIFF
--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -90,8 +90,6 @@
   border: 1px solid #e4e4e4;
   border-radius: 8px;
   overflow-x: auto;
-  overflow-y: auto;
-  max-height: 500px;
   position: relative;
   box-shadow: 0 1px 4px rgba(0, 0, 0, .06);
 }
@@ -102,9 +100,6 @@
 }
 
 .sm-table thead th {
-  position: sticky;
-  top: 0;
-  z-index: 10;
   background: #f5f6f8;
   font-size: 12px;
   font-weight: 600;


### PR DESCRIPTION
## Description

Fixes #55.

This PR removes nested scrolling from the Social Media Posts and Publishing Log pages.

## Changes

- Removed the fixed `500px` height from `.sm-table-wrap`
- Removed `overflow-y: auto` to eliminate the inner vertical scrollbar
- Kept `overflow-x: auto` for narrow screens
- Removed the sticky table header that depended on the inner scroll container

## Testing

<img width="1454" height="755" alt="Screenshot 2026-08-22 at 1 11 06 PM" src="https://github.com/user-attachments/assets/a2a1452c-d66a-4ac8-bd7e-f4f985c33875" />

<img width="1454" height="755" alt="Screenshot 2026-08-22 at 1 11 21 PM" src="https://github.com/user-attachments/assets/470851fb-9cba-4d9e-91a0-ac25c4bd2b6b" />

<img width="1454" height="755" alt="Screenshot 2026-08-22 at 1 12 36 PM" src="https://github.com/user-attachments/assets/7471d1d7-68b5-4637-992a-3e8e3948318f" />



Verified that:

- Social Media → Posts no longer has nested vertical scrolling
- Social Media → Publishing Log no longer has nested vertical scrolling
- The page handles vertical scrolling normally
- Tables expand naturally with their content
- Horizontal overflow is still handled on narrow screens
- Existing post functionality continues to work

## Summary by Sourcery

Simplify social media table scrolling so pages use normal vertical scrolling without nested scrollbars.

Bug Fixes:
- Remove nested vertical scrolling from Social Media Posts and Publishing Log tables.

Enhancements:
- Allow social media tables to expand naturally while retaining horizontal scrolling on narrow screens.
- Remove sticky table headers that relied on the inner scroll container.